### PR TITLE
Redesign homepage flow

### DIFF
--- a/assets/css/content.css
+++ b/assets/css/content.css
@@ -54,6 +54,89 @@ a:hover {
     line-height: 1.7;
 }
 
+.experience-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.5rem;
+}
+
+.experience-card {
+    background: var(--white);
+    padding: 2rem;
+    border-radius: 24px;
+    box-shadow: var(--shadow-soft);
+    border: 1px solid rgba(16, 19, 26, 0.05);
+}
+
+.experience-card h3 {
+    margin: 0 0 0.75rem;
+    color: var(--ink-900);
+}
+
+.journey-section {
+    background: var(--stone-50);
+}
+
+.journey-panel {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    align-items: center;
+    padding: 2.5rem;
+    margin: 0 auto 2.5rem;
+    width: min(1100px, 90%);
+    background: var(--white);
+    border-radius: 32px;
+    box-shadow: var(--shadow-soft);
+}
+
+.journey-panel.reverse {
+    direction: rtl;
+}
+
+.journey-panel.reverse > * {
+    direction: ltr;
+}
+
+.journey-media img {
+    border-radius: 24px;
+    box-shadow: 0 18px 35px rgba(16, 19, 26, 0.15);
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.journey-content h3 {
+    margin: 0 0 0.75rem;
+    color: var(--ink-900);
+    font-size: 1.6rem;
+}
+
+.media-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    align-items: stretch;
+}
+
+.stay-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    padding: 2.5rem;
+    border-radius: 32px;
+    background: linear-gradient(120deg, rgba(198, 106, 124, 0.1), rgba(178, 72, 90, 0.05));
+    box-shadow: var(--shadow-soft);
+    margin-bottom: 2.5rem;
+}
+
+.stay-card h2 {
+    font-family: "Playfair Display", serif;
+    color: var(--ink-900);
+    margin: 0 0 0.75rem;
+}
+
 .card-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -167,6 +250,18 @@ a:hover {
     background: var(--white);
     margin: 0 auto 2.5rem;
     width: min(100%, 920px);
+}
+
+.media-grid .media-frame {
+    width: 100%;
+    margin: 0;
+}
+
+@media (max-width: 767px) {
+    .stay-card {
+        flex-direction: column;
+        text-align: center;
+    }
 }
 
 .media-frame iframe {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -156,8 +156,63 @@ header nav {
     gap: 1rem;
 }
 
+.hero-scroll {
+    position: absolute;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.scroll-indicator {
+    width: 2px;
+    height: 36px;
+    background: rgba(255, 255, 255, 0.6);
+    border-radius: 999px;
+    position: relative;
+    overflow: hidden;
+}
+
+.scroll-indicator::after {
+    content: "";
+    position: absolute;
+    top: -40%;
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    width: 2px;
+    height: 50%;
+    background: var(--white);
+    animation: scrollPulse 2.4s ease-in-out infinite;
+}
+
+@keyframes scrollPulse {
+    0% {
+        transform: translateY(-60%);
+        opacity: 0;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        transform: translateY(120%);
+        opacity: 0;
+    }
+}
+
 @media (max-width: 767px) {
     .hero-content {
         padding: 7rem 0 5rem;
+    }
+
+    .hero-scroll {
+        bottom: 1.25rem;
     }
 }

--- a/views/index.html
+++ b/views/index.html
@@ -32,9 +32,10 @@
                 <div class="pure-menu pure-menu-horizontal custom-can-transform">
                     <ul class="pure-menu-list">
                         <li class="pure-menu-item"><a href="/wedding.html" class="pure-menu-link">Wedding Details</a></li>
-                        <li class="pure-menu-item"><a href="#proposal" class="pure-menu-link">Proposal</a></li>
-                        <li class="pure-menu-item"><a href="#highlights" class="pure-menu-link">Highlights</a></li>
-                        <li class="pure-menu-item"><a href="#story" class="pure-menu-link">Our Story</a></li>
+                        <li class="pure-menu-item"><a href="#experience" class="pure-menu-link">Experience</a></li>
+                        <li class="pure-menu-item"><a href="#journey" class="pure-menu-link">Journey</a></li>
+                        <li class="pure-menu-item"><a href="#films" class="pure-menu-link">Films</a></li>
+                        <li class="pure-menu-item"><a href="#stay" class="pure-menu-link">Stay</a></li>
                         <li class="pure-menu-item"><a href="#photos" class="pure-menu-link">Photos</a></li>
                     </ul>
                 </div>
@@ -50,43 +51,109 @@
             <div class="hero-content">
                 <p class="eyebrow">May 21, 2016 • Pleasanton, California</p>
                 <h1>Frances &amp; David</h1>
-                <p class="hero-subtitle">A photo-first story of the proposal, the wedding, and the early days that brought us together.</p>
+                <p class="hero-subtitle">A flowing story of the proposal, the wedding, and the little milestones that brought us together—designed to move like the journey itself.</p>
                 <div class="hero-actions">
-                    <a class="button-primary" href="#proposal">Watch the proposal</a>
+                    <a class="button-primary" href="#films">Watch the films</a>
                     <a class="button-secondary" href="/wedding.html">See wedding details</a>
+                </div>
+            </div>
+            <div class="hero-scroll">
+                <span>Scroll</span>
+                <div class="scroll-indicator"></div>
+            </div>
+        </section>
+
+        <section id="experience" class="section section-alt">
+            <div class="section-heading container">
+                <p class="eyebrow">The Experience</p>
+                <h2 class="section-title">A wedding weekend that moves with you</h2>
+                <p class="section-lede">Inspired by the immersive flow of Lightship RV, each chapter transitions into the next—highlighting the people, places, and moments that matter most.</p>
+            </div>
+            <div class="container experience-grid">
+                <article class="experience-card">
+                    <p class="eyebrow">Celebrate</p>
+                    <h3>Moments staged for connection</h3>
+                    <p>From welcome drinks to the final dance, every gathering is choreographed to keep loved ones close.</p>
+                </article>
+                <article class="experience-card">
+                    <p class="eyebrow">Explore</p>
+                    <h3>Travel-ready weekend planning</h3>
+                    <p>Settle into the vineyard, discover Pleasanton favorites, and move effortlessly between events.</p>
+                </article>
+                <article class="experience-card">
+                    <p class="eyebrow">Remember</p>
+                    <h3>Photo-first storytelling</h3>
+                    <p>Large imagery and cinematic clips guide you through the highlights without leaving the page.</p>
+                </article>
+            </div>
+        </section>
+
+        <section id="journey" class="section journey-section">
+            <div class="section-heading container">
+                <p class="eyebrow">The Journey</p>
+                <h2 class="section-title">A guided flow through our story</h2>
+                <p class="section-lede">Like the cinematic, scroll-led experience of Lightship RV, each moment builds on the next—anchored by imagery and an effortless cadence.</p>
+            </div>
+            <div class="journey-panel">
+                <div class="journey-media">
+                    <img src="assets/images/wedding_highlight_bride_vineyard.jpg" alt="Frances in the vineyard with bouquet"/>
+                </div>
+                <div class="journey-content">
+                    <p class="eyebrow">Chapter One</p>
+                    <h3>The early adventures</h3>
+                    <p>Late-night study sessions, long-distance calls, and spontaneous concerts set the tone for everything that followed.</p>
+                </div>
+            </div>
+            <div class="journey-panel reverse">
+                <div class="journey-media">
+                    <img src="assets/images/wedding_highlight_groom.jpg" alt="David getting ready with a red tie"/>
+                </div>
+                <div class="journey-content">
+                    <p class="eyebrow">Chapter Two</p>
+                    <h3>Growing into a home</h3>
+                    <p>Seven years, six apartments, and four cities later, we built a home that welcomes every guest who joins us.</p>
+                </div>
+            </div>
+            <div class="journey-panel">
+                <div class="journey-media">
+                    <img src="assets/images/wedding_highlight_sunset.jpg" alt="Silhouette kiss at sunset"/>
+                </div>
+                <div class="journey-content">
+                    <p class="eyebrow">Chapter Three</p>
+                    <h3>The evening glow</h3>
+                    <p>Sunset portraits and candlelit dances bring the story to a close, but the celebration continues.</p>
                 </div>
             </div>
         </section>
 
-        <section id="proposal" class="section">
+        <section id="films" class="section section-alt">
             <div class="section-heading container">
-                <p class="eyebrow">The Engagement</p>
-                <h2 class="section-title">The moment it all started</h2>
-                <p class="section-lede">When Frances moved back home from Massachusetts, David promised to keep her close—and he proposed.</p>
+                <p class="eyebrow">The Films</p>
+                <h2 class="section-title">Cinematic highlights, right in the flow</h2>
+                <p class="section-lede">Two films anchor the experience: the proposal and the wedding day. Watch them without leaving the page.</p>
             </div>
-            <div class="container media-frame">
-                <iframe src="https://www.youtube.com/embed/FPimCVb5IhA" title="Proposal film" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <div class="container media-grid">
+                <div class="media-frame">
+                    <iframe src="https://www.youtube.com/embed/FPimCVb5IhA" title="Proposal film" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                </div>
+                <div class="media-frame">
+                    <iframe src="https://player.vimeo.com/video/171783323?autoplay=0&title=0&byline=0&portrait=0" title="Wedding film" frameborder="0" allow="fullscreen"></iframe>
+                </div>
             </div>
         </section>
 
-        <section id="highlights" class="section section-alt">
-            <div class="section-heading container">
-                <p class="eyebrow">Wedding Highlights</p>
-                <h2 class="section-title">A photo-first look at our day</h2>
-                <p class="section-lede">From getting ready to the last dance, these frames capture the energy, laughter, and love.</p>
+        <section id="stay" class="section">
+            <div class="container stay-card">
+                <div>
+                    <p class="eyebrow">Plan your stay</p>
+                    <h2>Everything you need, mapped in one place</h2>
+                    <p>Visit the wedding details page for venue directions, hotel blocks, and registry information.</p>
+                </div>
+                <a class="button-primary" href="/wedding.html">Wedding details</a>
             </div>
             <div class="container photo-grid">
                 <figure class="photo-card">
-                    <img src="assets/images/wedding_highlight_groom.jpg" alt="David getting ready with a red tie"/>
-                </figure>
-                <figure class="photo-card">
-                    <img src="assets/images/wedding_highlight_bride_vineyard.jpg" alt="Frances in the vineyard with bouquet"/>
-                </figure>
-                <figure class="photo-card">
                     <img src="assets/images/wedding_highlight_roses.jpg" alt="Close-up of the bouquet and smiles"/>
-                </figure>
-                <figure class="photo-card">
-                    <img src="assets/images/wedding_highlight_sunset.jpg" alt="Silhouette kiss at sunset"/>
                 </figure>
                 <figure class="photo-card">
                     <img src="assets/images/wedding_highlight_money.jpg" alt="Playful wedding portrait with money garlands"/>
@@ -97,42 +164,6 @@
                 <figure class="photo-card">
                     <img src="assets/images/wedding_highlight_chandeliers.jpg" alt="Couple dancing under chandeliers"/>
                 </figure>
-            </div>
-            <div class="container media-frame">
-                <iframe src="https://player.vimeo.com/video/171783323?autoplay=0&title=0&byline=0&portrait=0" title="Wedding film" frameborder="0" allow="fullscreen"></iframe>
-            </div>
-        </section>
-
-        <section id="story" class="section">
-            <div class="section-heading container">
-                <p class="eyebrow">Our Story</p>
-                <h2 class="section-title">From UCSD to forever</h2>
-                <p class="section-lede">A friendship built on late-night study sessions, long-distance calls, and steady devotion.</p>
-            </div>
-            <div class="container split-feature">
-                <div class="split-card">
-                    <h3>Early days</h3>
-                    <p>Our first adventures were simple and full of laughter—concert nights, long walks, and milestones that made the distance feel smaller.</p>
-                </div>
-                <div class="split-media">
-                    <img src="assets/images/lupe_fiasco_concert_edited.jpg" alt="Early days at a Lupe Fiasco concert"/>
-                </div>
-            </div>
-            <div class="container split-feature reverse">
-                <div class="split-media">
-                    <img src="assets/images/first_anniversary_edited.jpg" alt="First anniversary portrait"/>
-                </div>
-                <div class="split-card">
-                    <h3>Growing together</h3>
-                    <p>Beach outings, shared meals, and movie nights turned their friendship into something more. Seven years, six apartments, and four cities later, we’re grateful for every chapter.</p>
-                </div>
-            </div>
-            <div class="container cta-card">
-                <div>
-                    <h3>Looking for the ceremony and travel details?</h3>
-                    <p>Find everything about the venue, hotels, and registry on our wedding details page.</p>
-                </div>
-                <a class="button-primary" href="/wedding.html">Wedding details</a>
             </div>
         </section>
 


### PR DESCRIPTION
### Motivation
- Move the homepage from a static, photo-first layout into a guided, scroll-led experience inspired by Lightship RV so the site reads like a continuous journey. 
- Surface cinematic content and travel/stay details inline to reduce context switching (watch films, browse story, find stay info without leaving the page). 

### Description
- Reorganized `views/index.html` to replace `#proposal`, `#highlights`, and `#story` with new anchors and sections: `#experience`, `#journey`, `#films`, and `#stay`, updated hero copy, and added a hero scroll indicator. 
- Added an `experience-grid` for top-level weekend highlights and a multi-panel `journey-panel` layout to present the story as chapters using large imagery. 
- Consolidated film embeds into a `media-grid` so proposal and wedding films are viewable inline, and added a `stay-card` + supporting photo grid for travel/venue content. 
- Added CSS rules in `assets/css/content.css` and `assets/css/main.css` for the new grids, panels, hero scroll indicator, and animations to support the new flow. 

### Testing
- Started the local server with `npm run local` which reported the Hapi server started at `http://127.0.0.1:8000`, and the command completed successfully. 
- Ran an automated Playwright script (Python) that opened the homepage and saved a full-page screenshot to `artifacts/francesanddavid-home.png`, confirming the new layout rendered (screenshot captured successfully). 
- `npm test` was not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696935076170832e84428aed4e0a0958)