### PR TITLE
Immersive homepage redesign, story archive, and theming updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ npm run local
 ```
 
 `npm run local` binds to `0.0.0.0` so browser automation and screenshot tools can reach the server through forwarded ports.
+It keeps the default `3000` port so Codex preview screenshots reach the correct service (port `8000` is reserved by the preview proxy).
 If you only bind to `127.0.0.1`, external browser containers will return a Not Found page.
 
 ## Running on Windows
@@ -31,14 +32,14 @@ by setting `HOST` and `PORT` in your shell first.
 **PowerShell**
 ```powershell
 $env:HOST="0.0.0.0"
-$env:PORT="8000"
+$env:PORT="3000"
 node index.js
 ```
 
 **Command Prompt (cmd.exe)**
 ```cmd
 set HOST=0.0.0.0
-set PORT=8000
+set PORT=3000
 node index.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Using:
 npm install
 npm run local
 ```
+
+`npm run local` binds to `0.0.0.0` so browser automation and screenshot tools can reach the server through forwarded ports.
+If you only bind to `127.0.0.1`, external browser containers will return a Not Found page.
+
 ## Running on Windows
 
 `npm run local` sets environment variables using a Unix-style prefix, so on Windows start the server
@@ -26,14 +30,14 @@ by setting `HOST` and `PORT` in your shell first.
 
 **PowerShell**
 ```powershell
-$env:HOST="127.0.0.1"
+$env:HOST="0.0.0.0"
 $env:PORT="8000"
 node index.js
 ```
 
 **Command Prompt (cmd.exe)**
 ```cmd
-set HOST=127.0.0.1
+set HOST=0.0.0.0
 set PORT=8000
 node index.js
 ```
@@ -159,3 +163,4 @@ sudo apt install -y certbot python3-certbot-nginx
 sudo certbot --nginx -d your-domain.com -d www.your-domain.com
 
 
+```

--- a/assets/css/content.css
+++ b/assets/css/content.css
@@ -26,12 +26,24 @@ a:hover {
 }
 
 .section {
-    padding: 5rem 0;
+    padding: 5.5rem 0;
     background: var(--white);
 }
 
 .section-alt {
     background: var(--stone-100);
+}
+
+.theme-immersive .section {
+    background: var(--night-900);
+}
+
+.theme-immersive .section-alt {
+    background: var(--night-800);
+}
+
+.section-immersive {
+    background: var(--night-800);
 }
 
 .section-heading {
@@ -52,6 +64,16 @@ a:hover {
     font-size: 1.05rem;
     color: var(--ink-500);
     line-height: 1.7;
+}
+
+.theme-immersive .section-title,
+.theme-immersive .section-lede,
+.theme-immersive .section-heading {
+    color: var(--stone-50);
+}
+
+.theme-immersive .section-lede {
+    color: rgba(255, 255, 255, 0.72);
 }
 
 .card-grid {
@@ -157,6 +179,15 @@ a:hover {
     color: var(--ink-500);
 }
 
+.theme-immersive .reference-links {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.theme-immersive .reference-links a {
+    color: var(--stone-50);
+    border-bottom-color: rgba(255, 255, 255, 0.5);
+}
+
 .reference-links a {
     color: var(--ink-900);
     text-decoration: none;
@@ -241,6 +272,11 @@ a:hover {
     border: 1px solid rgba(16, 19, 26, 0.04);
 }
 
+.theme-immersive .card {
+    background: rgba(15, 18, 24, 0.9);
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
 .card h3 {
     margin-top: 0;
     margin-bottom: 0.75rem;
@@ -259,6 +295,230 @@ a:hover {
     font-size: 0.95rem;
 }
 
+.hero-video {
+    position: relative;
+    min-height: 100vh;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.hero-video-media {
+    position: absolute;
+    inset: 0;
+}
+
+.hero-video-media iframe {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    inset: 0;
+}
+
+.hero-video-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(11, 13, 16, 0.65), rgba(11, 13, 16, 0.85));
+}
+
+.hero-video-content {
+    position: relative;
+    z-index: 2;
+    width: min(720px, 90%);
+    padding: 8rem 0 6rem;
+    color: var(--stone-50);
+}
+
+.hero-video-content h1 {
+    font-size: clamp(2.8rem, 6vw, 4.8rem);
+    margin-bottom: 1rem;
+}
+
+.page-hero {
+    position: relative;
+    min-height: 60vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    overflow: hidden;
+    background: var(--night-900);
+    color: var(--stone-50);
+}
+
+.page-hero-media img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.page-hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(12, 14, 18, 0.65), rgba(12, 14, 18, 0.85));
+}
+
+.page-hero-content {
+    position: relative;
+    z-index: 1;
+    padding: 7rem 0 4rem;
+    width: min(640px, 90%);
+}
+
+.page-hero-content h1 {
+    margin: 0 0 1rem;
+    font-size: clamp(2.4rem, 6vw, 3.8rem);
+}
+
+.hero-scroll {
+    margin-top: 2.5rem;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.hero-scroll-line {
+    width: 1px;
+    height: 38px;
+    background: rgba(255, 255, 255, 0.5);
+}
+
+.scroll-panel {
+    position: relative;
+    min-height: 110vh;
+    overflow: clip;
+    background: var(--night-900);
+}
+
+.scroll-panel-media {
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    width: 100%;
+}
+
+.scroll-panel-media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: saturate(0.95);
+}
+
+.scroll-panel-content {
+    position: relative;
+    min-height: 110vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6rem 0;
+}
+
+.scroll-panel-foreground {
+    width: min(900px, 88%);
+    transform: translateY(var(--scroll-offset, 0px));
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.panel-card {
+    background: rgba(15, 18, 24, 0.85);
+    border-radius: 32px;
+    padding: 2.5rem;
+    box-shadow: 0 30px 70px rgba(5, 5, 10, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: var(--stone-50);
+}
+
+.panel-card .section-title {
+    color: var(--stone-50);
+}
+
+.panel-card .section-lede {
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.panel-gallery {
+    margin-top: 2rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+}
+
+.panel-gallery img {
+    width: 100%;
+    height: 140px;
+    object-fit: cover;
+    border-radius: 18px;
+    box-shadow: 0 16px 30px rgba(0, 0, 0, 0.25);
+}
+
+.panel-icon-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+}
+
+.icon-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.65rem 1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.icon-chip-symbol {
+    font-size: 1rem;
+}
+
+.panel-story-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+}
+
+.panel-story-grid h3 {
+    margin-top: 0;
+    color: var(--stone-50);
+}
+
+.panel-story-grid p {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.panel-image-strip {
+    margin-top: 2rem;
+}
+
+.panel-image-strip img {
+    width: 100%;
+    border-radius: 24px;
+    object-fit: cover;
+    max-height: 320px;
+}
+
+[data-reveal] {
+    opacity: 0;
+    transform: translateY(24px);
+}
+
+[data-reveal].is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
 .media-frame {
     position: relative;
     padding-top: 56.25%;
@@ -268,6 +528,11 @@ a:hover {
     background: var(--white);
     margin: 0 auto 2.5rem;
     width: min(100%, 920px);
+}
+
+.theme-immersive .media-frame {
+    background: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 24px 50px rgba(0, 0, 0, 0.4);
 }
 
 .media-frame iframe {

--- a/assets/css/content.css
+++ b/assets/css/content.css
@@ -321,6 +321,7 @@ a:hover {
     position: absolute;
     inset: 0;
     background: linear-gradient(180deg, rgba(11, 13, 16, 0.65), rgba(11, 13, 16, 0.85));
+    transition: opacity 0.6s ease;
 }
 
 .hero-video-content {
@@ -329,11 +330,22 @@ a:hover {
     width: min(720px, 90%);
     padding: 8rem 0 6rem;
     color: var(--stone-50);
+    transition: opacity 0.6s ease, transform 0.6s ease;
 }
 
 .hero-video-content h1 {
     font-size: clamp(2.8rem, 6vw, 4.8rem);
     margin-bottom: 1rem;
+}
+
+.hero-video--clear .hero-video-content {
+    opacity: 0;
+    transform: translateY(-16px);
+    pointer-events: none;
+}
+
+.hero-video--clear .hero-video-overlay {
+    opacity: 0.35;
 }
 
 .page-hero {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -8,12 +8,20 @@
     --ink-900: #0c0c0c;
     --ink-700: #202020;
     --ink-500: #545454;
+    --ink-200: #c4c4c4;
     --brand-600: #b04e5f;
     --brand-500: #c06a78;
     --brand-200: #f5e1e5;
+    --brand-100: #f9ecf0;
     --stone-50: #ffffff;
     --stone-100: #f7f7f7;
     --white: #ffffff;
+    --night-900: #0b0d10;
+    --night-800: #151822;
+    --linen-100: #f2efe9;
+    --nav-bg: rgba(255, 255, 255, 0.9);
+    --nav-text: var(--ink-700);
+    --nav-border: rgba(16, 19, 26, 0.08);
     --shadow-soft: 0 22px 50px rgba(12, 12, 12, 0.12);
 }
 
@@ -31,7 +39,7 @@ body {
     -webkit-font-smoothing: antialiased;
     font-family: "Sora", sans-serif;
     color: var(--ink-900);
-    background: var(--white);
+    background: var(--linen-100);
 }
 
 img {
@@ -97,6 +105,28 @@ header nav {
 .button-secondary:hover {
     transform: translateY(-1px);
     background: var(--white);
+}
+
+.theme-immersive {
+    background: var(--night-900);
+    color: var(--stone-50);
+    --nav-bg: rgba(13, 16, 20, 0.76);
+    --nav-text: var(--stone-50);
+    --nav-border: rgba(255, 255, 255, 0.12);
+}
+
+.theme-immersive .eyebrow {
+    color: var(--brand-200);
+}
+
+.theme-immersive .button-secondary {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--stone-50);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.theme-immersive .button-secondary:hover {
+    background: rgba(255, 255, 255, 0.2);
 }
 
 .hero {

--- a/assets/css/nav.css
+++ b/assets/css/nav.css
@@ -3,7 +3,7 @@ NAVIGATION STYLES
  */
 
 #menu .pure-menu-item a.pure-menu-link {
-    color: var(--ink-700);
+    color: var(--nav-text);
     text-transform: uppercase;
     border-radius: 999px;
     font-family: "Sora", sans-serif;
@@ -13,7 +13,7 @@ NAVIGATION STYLES
 }
 
 #menu .pure-menu-item a.pure-menu-link:hover {
-    background: rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.18);
 }
 
 #menu .pure-menu ul.pure-menu-list {
@@ -27,7 +27,7 @@ NAVIGATION STYLES
 .custom-brand {
     font-family: "Sora", sans-serif;
     letter-spacing: 0.08em;
-    color: var(--ink-900);
+    color: var(--nav-text);
 }
 
 /*
@@ -42,9 +42,9 @@ NAVIGATION STYLES
     -ms-transition: height 0.5s;
     transition: height 0.5s;
     width: 100%;
-    background-color: rgba(255, 255, 255, 0.92);
+    background-color: var(--nav-bg);
     backdrop-filter: blur(12px);
-    border-bottom: 1px solid rgba(16, 19, 26, 0.08);
+    border-bottom: 1px solid var(--nav-border);
 }
 
 /*MODIFY: When adding a new menu button 3em per item*/
@@ -71,7 +71,7 @@ NAVIGATION STYLES
 }
 
 .custom-toggle .bar {
-    background-color: var(--ink-700);
+    background-color: var(--nav-text);
     display: block;
     width: 20px;
     height: 2px;

--- a/assets/images/geisel_library_ucsd.svg
+++ b/assets/images/geisel_library_ucsd.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2400 1600">
+  <defs>
+    <linearGradient id="sky" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1b2b4a"/>
+      <stop offset="55%" stop-color="#2b4b6f"/>
+      <stop offset="100%" stop-color="#d9c9b3"/>
+    </linearGradient>
+    <linearGradient id="plaza" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#d8cbb9"/>
+      <stop offset="100%" stop-color="#bcae9d"/>
+    </linearGradient>
+  </defs>
+  <rect width="2400" height="1600" fill="url(#sky)"/>
+  <rect y="1120" width="2400" height="480" fill="url(#plaza)"/>
+  <rect y="980" width="2400" height="180" fill="#3e4b59" opacity="0.4"/>
+  <g transform="translate(300 420)">
+    <rect x="360" y="520" width="1080" height="260" fill="#4b4b4f"/>
+    <rect x="420" y="420" width="960" height="110" fill="#3e3f44"/>
+    <rect x="520" y="320" width="760" height="120" fill="#2f3138"/>
+    <rect x="600" y="180" width="600" height="160" fill="#252730"/>
+    <g fill="#1f2026">
+      <polygon points="0,520 320,420 320,760 0,820"/>
+      <polygon points="1800,520 1480,420 1480,760 1800,820"/>
+    </g>
+    <g fill="#343843">
+      <rect x="0" y="820" width="1800" height="140"/>
+      <rect x="140" y="780" width="1500" height="60"/>
+    </g>
+    <g fill="#1b1c21" opacity="0.65">
+      <rect x="720" y="230" width="360" height="90"/>
+      <rect x="690" y="340" width="420" height="60"/>
+    </g>
+  </g>
+  <g fill="#f4efe6" opacity="0.18">
+    <circle cx="420" cy="320" r="6"/>
+    <circle cx="520" cy="240" r="4"/>
+    <circle cx="1920" cy="300" r="5"/>
+    <circle cx="1680" cy="220" r="4"/>
+  </g>
+</svg>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -177,41 +177,60 @@ $(window).load(function() {
     }
 });
 
-var highlightGrid = document.querySelector('[data-highlight-grid]');
-if (highlightGrid) {
-    var highlightTiles = Array.prototype.slice.call(highlightGrid.querySelectorAll('.highlight-tile'));
-    var highlightSection = highlightGrid.closest('section') || highlightGrid;
-    var highlightTicking = false;
+var scrollSections = Array.prototype.slice.call(document.querySelectorAll('[data-scroll-section]'));
+var revealTargets = Array.prototype.slice.call(document.querySelectorAll('[data-reveal]'));
+var scrollTicking = false;
 
-    var clamp = function(value, min, max) {
-        return Math.min(Math.max(value, min), max);
-    };
+var clamp = function(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+};
 
-    var updateHighlightTiles = function() {
-        var rect = highlightSection.getBoundingClientRect();
-        var windowHeight = window.innerHeight || document.documentElement.clientHeight;
-        var progress = (windowHeight - rect.top) / (rect.height + windowHeight * 0.4);
-        var clampedProgress = clamp(progress, 0, 1);
-        var segment = 1 / highlightTiles.length;
+var updateScrollPanels = function() {
+    var viewportHeight = window.innerHeight || document.documentElement.clientHeight;
 
-        highlightTiles.forEach(function(tile, index) {
-            var localProgress = clamp((clampedProgress - segment * index) / segment, 0, 1);
-            var scale = 0.95 + 0.1 * localProgress;
-            tile.style.transform = 'scale(' + scale.toFixed(3) + ')';
-            tile.style.boxShadow = '0 22px 50px rgba(12, 12, 12, ' + (0.08 + 0.12 * localProgress).toFixed(2) + ')';
-        });
-
-        highlightTicking = false;
-    };
-
-    var requestHighlightUpdate = function() {
-        if (!highlightTicking) {
-            window.requestAnimationFrame(updateHighlightTiles);
-            highlightTicking = true;
+    scrollSections.forEach(function(section) {
+        var foreground = section.querySelector('[data-scroll-foreground]');
+        if (!foreground) {
+            return;
         }
-    };
 
-    window.addEventListener('scroll', requestHighlightUpdate, { passive: true });
-    window.addEventListener('resize', requestHighlightUpdate);
-    requestHighlightUpdate();
+        var rect = section.getBoundingClientRect();
+        var progress = (viewportHeight - rect.top) / (rect.height + viewportHeight);
+        var clampedProgress = clamp(progress, 0, 1);
+        var offset = (0.5 - clampedProgress) * 140;
+
+        foreground.style.setProperty('--scroll-offset', offset.toFixed(1) + 'px');
+    });
+
+    scrollTicking = false;
+};
+
+var requestScrollUpdate = function() {
+    if (!scrollTicking) {
+        window.requestAnimationFrame(updateScrollPanels);
+        scrollTicking = true;
+    }
+};
+
+if (scrollSections.length) {
+    window.addEventListener('scroll', requestScrollUpdate, { passive: true });
+    window.addEventListener('resize', requestScrollUpdate);
+    requestScrollUpdate();
+}
+
+if (revealTargets.length) {
+    var revealObserver = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('is-visible');
+                revealObserver.unobserve(entry.target);
+            }
+        });
+    }, {
+        threshold: 0.2
+    });
+
+    revealTargets.forEach(function(target) {
+        revealObserver.observe(target);
+    });
 }

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -180,6 +180,7 @@ $(window).load(function() {
 var scrollSections = Array.prototype.slice.call(document.querySelectorAll('[data-scroll-section]'));
 var revealTargets = Array.prototype.slice.call(document.querySelectorAll('[data-reveal]'));
 var scrollTicking = false;
+var heroSection = document.querySelector('.hero-video');
 
 var clamp = function(value, min, max) {
     return Math.min(Math.max(value, min), max);
@@ -218,6 +219,15 @@ if (scrollSections.length) {
     requestScrollUpdate();
 }
 
+if (heroSection) {
+    var updateHeroVisibility = function() {
+        heroSection.classList.toggle('hero-video--clear', window.scrollY > 40);
+    };
+
+    window.addEventListener('scroll', updateHeroVisibility, { passive: true });
+    updateHeroVisibility();
+}
+
 if (revealTargets.length) {
     var revealObserver = new IntersectionObserver(function(entries) {
         entries.forEach(function(entry) {
@@ -232,5 +242,23 @@ if (revealTargets.length) {
 
     revealTargets.forEach(function(target) {
         revealObserver.observe(target);
+    });
+}
+
+var proposalTrigger = document.querySelector('[data-proposal-trigger]');
+if (proposalTrigger) {
+    proposalTrigger.addEventListener('click', function() {
+        var proposalVideo = document.querySelector('[data-proposal-video]');
+        if (proposalVideo) {
+            var autoplaySrc = proposalVideo.getAttribute('data-autoplay-src');
+            if (autoplaySrc && proposalVideo.src !== autoplaySrc) {
+                proposalVideo.src = autoplaySrc;
+            }
+        }
+
+        var vimeoHero = document.getElementById('vimeo-hero');
+        if (vimeoHero && vimeoHero.contentWindow) {
+            vimeoHero.contentWindow.postMessage(JSON.stringify({ method: 'pause' }), '*');
+        }
     });
 }

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -181,6 +181,7 @@ var scrollSections = Array.prototype.slice.call(document.querySelectorAll('[data
 var revealTargets = Array.prototype.slice.call(document.querySelectorAll('[data-reveal]'));
 var scrollTicking = false;
 var heroSection = document.querySelector('.hero-video');
+var heroContent = heroSection ? heroSection.querySelector('.hero-video-content') : null;
 
 var clamp = function(value, min, max) {
     return Math.min(Math.max(value, min), max);
@@ -219,13 +220,15 @@ if (scrollSections.length) {
     requestScrollUpdate();
 }
 
-if (heroSection) {
+if (heroSection && heroContent) {
     var updateHeroVisibility = function() {
         heroSection.classList.toggle('hero-video--clear', window.scrollY > 40);
     };
 
     window.addEventListener('scroll', updateHeroVisibility, { passive: true });
     updateHeroVisibility();
+} else if (heroSection) {
+    heroSection.classList.add('hero-video--clear');
 }
 
 if (revealTargets.length) {

--- a/assets/js/program.js
+++ b/assets/js/program.js
@@ -1,3 +1,22 @@
 $(window).load(function(){
     $('#pleaseNoPhotos').modal('show');
 });
+
+var revealTargets = Array.prototype.slice.call(document.querySelectorAll('[data-reveal]'));
+
+if (revealTargets.length) {
+    var revealObserver = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('is-visible');
+                revealObserver.unobserve(entry.target);
+            }
+        });
+    }, {
+        threshold: 0.2
+    });
+
+    revealTargets.forEach(function(target) {
+        revealObserver.observe(target);
+    });
+}

--- a/docs/Story.MD
+++ b/docs/Story.MD
@@ -1,0 +1,142 @@
+# Frances + David Website Story Archive
+
+## Home Page (Our Story)
+
+### Wedding Film
+- **Heading:** The vows, the cheers, the first dance
+- **Subtitle:** The wedding day memories locked in a time capsule.
+- **Video (Vimeo embed):** https://player.vimeo.com/video/171783323?autoplay=1&muted=1&autopause=0&title=0&byline=0&portrait=0
+
+### Wedding Highlights
+- **Heading:** A decade later, the day still glows
+- **Subtitle:** Ten years on, these snapshots still feel like the opening chapter of everything that followed.
+- **Images:**
+  - `assets/images/wedding_highlight_bride_vineyard.jpg` — “Frances in the vineyard with bouquet”
+  - `assets/images/wedding_highlight_sunset.jpg` — “Silhouette kiss at sunset”
+  - `assets/images/wedding_highlight_groom.jpg` — “David getting ready with a red tie”
+  - `assets/images/wedding_highlight_roses.jpg` — “Close-up of the bouquet and smiles”
+  - `assets/images/wedding_highlight_money.jpg` — “Playful wedding portrait with money garlands”
+  - `assets/images/wedding_highlight_palms.jpg` — “Night dance under palm trees”
+  - `assets/images/wedding_highlight_chandeliers.jpg` — “Couple dancing under chandeliers”
+
+### The Engagement
+- **Heading:** A promise kept close
+- **Story text:**
+  - “When Frances moved back home from Massachusetts, David promised to keep her close—and he proposed.”
+  - “That quiet promise turned into a celebration, the start of a timeline the two of them keep adding to every year.”
+- **Image:** `assets/images/engagement.jpg` — “Frances and David engagement portrait”
+- **Video (YouTube embed):** https://www.youtube.com/embed/FPimCVb5IhA
+
+### College Beginnings
+- **Heading:** How they met at UCSD
+- **Subtitle:** Study sessions, late-night meals, and spontaneous adventures laid the foundation for everything that followed.
+- **Story blocks:**
+  - **Campus nights:** “They met in college, bonding over group projects and long talks that stretched into the early hours. The friendship felt effortless and steady from the start.”
+  - **Favorite memories:** “Concert nights, beach sunsets, and every first apartment meal became the stories they still laugh about today.”
+- **Images:**
+  - `assets/images/lupe_fiasco_concert_edited.jpg` — “Early days at a Lupe Fiasco concert”
+  - `assets/images/first_anniversary_edited.jpg` — “First anniversary portrait”
+
+### Photo Journal
+- **Heading:** Snapshots they keep adding to
+- **Gallery source:** Flickr photoset `72157647621851886`
+
+### Reference Links
+- Wedding details: `/wedding.html`
+- Wedding program: `/program`
+
+---
+
+## Wedding Details Page
+
+### Hero
+- **Eyebrow:** Wedding Details
+- **Date:** May 21, 2016
+- **Subtitle:** Everything you need to know for the ceremony, reception, and weekend stay.
+- **CTA:** “See the schedule” and “Back to our story”
+- **Hero image:** `assets/images/PalmEventCenter1_resized.jpg` — “Palm Event Center vineyards”
+
+### The Wedding
+- **Heading:** A vineyard celebration in Pleasanton
+- **Lead:** We gathered our favorite people for a warm, sunlit day at the Palm Event Center, with the ceremony and reception all in one place.
+- **Date:** Saturday, May 21st, 2016
+- **Schedule:** Doors open at 4:30 PM · Ceremony begins at 5:00 PM
+- **Venue:** Palm Event Center in the Vineyard, Pleasanton, California
+- **Address:** 1184 Vineyard Ave, Pleasanton, CA 94566
+- **Attire:** Garden formal — polished, soft colors, and comfortable shoes for the vineyards.
+
+### Venue
+- **Heading:** Palm Event Center in the Vineyard
+- **Lead:** A sunlit estate with vineyard views made the perfect setting for our ceremony and reception.
+- **Images:**
+  - `assets/images/PalmEventCenter1_resized.jpg` — “Palm Event Center exterior”
+  - `assets/images/PalmEventCenter3_resized.jpg` — “Palm Event Center vineyards”
+
+### Getting There
+- **Heading:** Ceremony, reception, and nearby stays
+- **Map locations:**
+  - **Ceremony & Reception:** The Palm Event Center
+  - **Hotels:** Courtyard Marriott, Hampton Inn
+  - **Airports:** Oakland Int'l Airport (OAK), San Jose Int'l Airport (SJC), San Francisco Int'l Airport (SFO)
+
+### Stay With Us (Hotel accommodations)
+- **Lead:** We reserved room blocks so you can stay close to the venue and join in the weekend festivities.
+- **Courtyard by Marriott**
+  - $129 per night · May 20 - May 22
+  - Preferred hotel of the bride and groom. Shuttle service is provided.
+  - Reservation link: http://www.marriott.com/meeting-event-hotels/group-corporate-travel/groupCorp.mi?resLinkData=Duldulao-Dizon%20Wedding%5Eoaklm%60DULDULA%7CDULDULB%60129.00%60USD%60false%604%605/20/16%605/22/16%604/22/16&app=resvlink&stop_mobi=yes
+  - Image: `assets/images/courtyardmarriot.jpg` — “Courtyard Marriott Livermore”
+  - Address: 2929 Constitution Drive, Livermore, California 94550 · 925-243-1000
+- **Hampton Inn by Hilton**
+  - $109 per night · May 20 - May 22
+  - Book under “Duldulao Dizon Wedding” or use group code **WDD**.
+  - Reservation link: http://hamptoninn3.hilton.com/en/hotels/california/hampton-inn-livermore-LVKCAHX/index.html
+  - Image: `assets/images/hamptoninn.jpg` — “Hampton Inn Livermore”
+  - Address: 2850 Constitution Drive, Livermore, CA 94551 · 925-606-6400
+
+### Registry
+- **Lead:** Because we already combined two homes, we focused on upgrades and future experiences.
+- **The Knot:** http://registry.theknot.com/frances-duldulao-david-dizon-may-2016-ca/13028899
+- **Zola:** https://www.zola.com/registry/francesanddavid
+- **Logos:**
+  - `assets/images/theknot_logo1.PNG` — “The Knot”
+  - `assets/images/zola_logo.jpg` — “Zola”
+
+---
+
+## Wedding Program Page
+
+### Wedding Ceremony
+- Prelude
+- Seating of grandparents
+- Processional
+- Bridal processional
+- Declaration of consent
+- Welcome
+- Opening prayer — Rev. Denny Bellesi
+- Scripture reading — Song of Solomon 8:6-7 by Richard Salcedo
+- Message
+- Exchange of vows
+- Exchange of rings
+- Cord & veil
+- Communion
+- Prayer of blessing
+- Pronouncement of marriage
+- Presentation of the couple
+- Recessional
+
+### The Wedding Party
+- **Grandparents of the Bride:** Benedicto & Feliza Duldulao
+- **Parents of the Bride:** Lester & Filipinas Duldulao
+- **Parents of the Groom:** Emmanuel & Jocyline Dizon
+- **Maid of Honor:** Leslie Duldulao
+- **Best Man:** Caz Salamanca
+- **Bridesmaids:** Lyca Segal, Sherry Goldstein, Veronica Stimson
+- **Groomsmen:** Victor Dizon, Eric Goldstein, St. John Johnson
+- **Flower Girl:** Angela Dizon
+- **Officiant:** Rev. Denny Bellesi
+
+### Message from the Bride and Groom
+- “We hired an awesome photographer, and we would really like him to capture the moments during our ceremony.”
+- “Please do not take photos during the ceremony. Don't worry, we will share them.”
+- **Image:** `/assets/images/no-camera-allowed.png`

--- a/docs/Story.MD
+++ b/docs/Story.MD
@@ -24,8 +24,9 @@
 - **Story text:**
   - “When Frances moved back home from Massachusetts, David promised to keep her close—and he proposed.”
   - “That quiet promise turned into a celebration, the start of a timeline the two of them keep adding to every year.”
-- **Image:** `assets/images/engagement.jpg` — “Frances and David engagement portrait”
+- **Background image:** `assets/images/wedding_highlight_palms.jpg` — “Night dance under palm trees”
 - **Video (YouTube embed):** https://www.youtube.com/embed/FPimCVb5IhA
+  - **CTA:** “2014 proposal film” scrolls to the proposal film section.
 
 ### College Beginnings
 - **Heading:** How they met at UCSD
@@ -33,9 +34,8 @@
 - **Story blocks:**
   - **Campus nights:** “They met in college, bonding over group projects and long talks that stretched into the early hours. The friendship felt effortless and steady from the start.”
   - **Favorite memories:** “Concert nights, beach sunsets, and every first apartment meal became the stories they still laugh about today.”
-- **Images:**
-  - `assets/images/lupe_fiasco_concert_edited.jpg` — “Early days at a Lupe Fiasco concert”
-  - `assets/images/first_anniversary_edited.jpg` — “First anniversary portrait”
+- **Background image:** `assets/images/geisel_library_ucsd.svg` — “Geisel Library at UC San Diego”
+- **Image:** `assets/images/first_anniversary_edited.jpg` — “First anniversary portrait”
 
 ### Photo Journal
 - **Heading:** Snapshots they keep adding to

--- a/docs/tasks/003-timeline-experience-refresh.md
+++ b/docs/tasks/003-timeline-experience-refresh.md
@@ -25,6 +25,7 @@ Cite this prompt in the task file that you're creating."
 - [ ] Reorder the homepage sections to match the requested timeline flow.
 - [ ] Use existing wedding highlight photos in a full-width layout.
 - [ ] Autoplay the Vimeo wedding film on load (muted).
+- [ ] Present the wedding film as a full-bleed hero without the foreground text panel.
 - [ ] Move the engagement hero image into the timeline with the requested narrative.
 - [ ] Add a story segment for college memories and favorites.
 - [ ] Add subtle wedding details + program links at the bottom.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "node tests/smoke-test.js",
     "start": "node index.js",
-    "local": "HOST=0.0.0.0 PORT=8000 node index.js"
+    "local": "HOST=0.0.0.0 node index.js"
   },
   "author": "David Dizon",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "node tests/smoke-test.js",
     "start": "node index.js",
-    "local": "HOST=127.0.0.1 PORT=8000 node index.js"
+    "local": "HOST=0.0.0.0 PORT=8000 node index.js"
   },
   "author": "David Dizon",
   "license": "MIT",

--- a/views/index.html
+++ b/views/index.html
@@ -64,7 +64,7 @@
 
         <section id="highlights" class="scroll-panel" data-scroll-section>
             <div class="scroll-panel-media" data-scroll-media>
-                <img src="assets/images/wedding_highlight_bride_vineyard.jpg" alt="Frances in the vineyard with bouquet"/>
+                <img src="assets/images/wedding_highlight_palms.jpg" alt="Frances in the vineyard with bouquet"/>
             </div>
             <div class="scroll-panel-content">
                 <div class="scroll-panel-foreground" data-scroll-foreground data-reveal>
@@ -73,12 +73,13 @@
                         <h2 class="section-title">A decade later, the day still glows</h2>
                         <p class="section-lede">Ten years on, these snapshots still feel like the opening chapter of everything that followed.</p>
                         <div class="panel-gallery">
-                            <img src="assets/images/wedding_highlight_sunset.jpg" alt="Silhouette kiss at sunset"/>
+                            <img src="assets/images/wedding_highlight_bride_vineyard.jpg" alt="Bride at the vineyard"/>
                             <img src="assets/images/wedding_highlight_groom.jpg" alt="David getting ready with a red tie"/>
                             <img src="assets/images/wedding_highlight_roses.jpg" alt="Close-up of the bouquet and smiles"/>
+                            <img src="assets/images/wedding_highlight_sunset.jpg" alt="Silhouette kiss at sunset"/>
+                            <img src="assets/images/wedding_highlight_chandeliers.jpg" alt="Couple dancing under chandeliers"/>
                             <img src="assets/images/wedding_highlight_money.jpg" alt="Playful wedding portrait with money garlands"/>
                             <img src="assets/images/wedding_highlight_palms.jpg" alt="Night dance under palm trees"/>
-                            <img src="assets/images/wedding_highlight_chandeliers.jpg" alt="Couple dancing under chandeliers"/>
                         </div>
                     </div>
                 </div>
@@ -87,7 +88,7 @@
 
         <section id="engagement" class="scroll-panel" data-scroll-section>
             <div class="scroll-panel-media" data-scroll-media>
-                <img src="assets/images/wedding_highlight_palms.jpg" alt="Night dance under palm trees"/>
+                <img src="assets/images/engagement.jpg" alt="Night dance under palm trees"/>
             </div>
             <div class="scroll-panel-content">
                 <div class="scroll-panel-foreground" data-scroll-foreground data-reveal>

--- a/views/index.html
+++ b/views/index.html
@@ -17,7 +17,7 @@
     <!--<![endif]-->
     <link rel="stylesheet" type="text/css" media="screen" href="assets/css/main.css"/>
 </head>
-<body>
+<body class="theme-immersive">
     <header>
         <nav class="custom-wrapper pure-g" id="menu">
             <div class="pure-u-1 pure-u-md-1-6">
@@ -35,96 +35,122 @@
                         <li class="pure-menu-item"><a href="#highlights" class="pure-menu-link">Highlights</a></li>
                         <li class="pure-menu-item"><a href="#engagement" class="pure-menu-link">Engagement</a></li>
                         <li class="pure-menu-item"><a href="#story" class="pure-menu-link">Story</a></li>
+                        <li class="pure-menu-item"><a href="#references" class="pure-menu-link">Details</a></li>
                     </ul>
                 </div>
             </div>
         </nav>
     </header>
     <main id="top">
-        <section id="film" class="section">
-            <div class="section-heading container">
-                <p class="eyebrow">Wedding Film</p>
-                <h2 class="section-title">The vows, the cheers, the first dance</h2>
-                <p class="section-lede">The wedding day memories locked in a time capsule.</p>
-            </div>
-            <div class="container media-frame">
+        <section id="film" class="hero-video">
+            <div class="hero-video-media">
                 <iframe src="https://player.vimeo.com/video/171783323?autoplay=1&muted=1&autopause=0&title=0&byline=0&portrait=0" title="Wedding film" frameborder="0" allow="autoplay; fullscreen"></iframe>
             </div>
-        </section>
-
-        <section id="highlights" class="section section-alt">
-            <div class="section-heading container">
-                <p class="eyebrow">Wedding Highlights</p>
-                <h2 class="section-title">A decade later, the day still glows</h2>
-                <p class="section-lede">Ten years on, these snapshots still feel like the opening chapter of everything that followed.</p>
-            </div>
-            <div class="highlight-grid" data-highlight-grid>
-                <figure class="highlight-tile highlight-tile--large">
-                    <img src="assets/images/wedding_highlight_bride_vineyard.jpg" alt="Frances in the vineyard with bouquet"/>
-                </figure>
-                <figure class="highlight-tile highlight-tile--medium">
-                    <img src="assets/images/wedding_highlight_sunset.jpg" alt="Silhouette kiss at sunset"/>
-                </figure>
-                <figure class="highlight-tile highlight-tile--standard">
-                    <img src="assets/images/wedding_highlight_groom.jpg" alt="David getting ready with a red tie"/>
-                </figure>
-                <figure class="highlight-tile highlight-tile--standard">
-                    <img src="assets/images/wedding_highlight_roses.jpg" alt="Close-up of the bouquet and smiles"/>
-                </figure>
-                <figure class="highlight-tile highlight-tile--standard">
-                    <img src="assets/images/wedding_highlight_money.jpg" alt="Playful wedding portrait with money garlands"/>
-                </figure>
-                <figure class="highlight-tile highlight-tile--standard">
-                    <img src="assets/images/wedding_highlight_palms.jpg" alt="Night dance under palm trees"/>
-                </figure>
-                <figure class="highlight-tile highlight-tile--standard">
-                    <img src="assets/images/wedding_highlight_chandeliers.jpg" alt="Couple dancing under chandeliers"/>
-                </figure>
-            </div>
-        </section>
-
-        <section id="engagement" class="section">
-            <div class="section-heading container">
-                <p class="eyebrow">The Engagement</p>
-                <h2 class="section-title">A promise kept close</h2>
-            </div>
-            <div class="image-panel">
-                <img src="assets/images/engagement.jpg" alt="Frances and David engagement portrait"/>
-                <div class="image-panel-content">
-                    <h3>When Frances moved back home from Massachusetts, David promised to keep her close—and he proposed.</h3>
-                    <p>That quiet promise turned into a celebration, the start of a timeline the two of them keep adding to every year.</p>
+            <div class="hero-video-overlay"></div>
+            <div class="hero-video-content" data-reveal>
+                <p class="eyebrow">Wedding Film</p>
+                <h1>The vows, the cheers, the first dance</h1>
+                <p class="hero-subtitle">The wedding day memories locked in a time capsule.</p>
+                <div class="hero-actions">
+                    <a class="button-primary" href="#highlights">Begin the story</a>
+                    <a class="button-secondary" href="#references">Wedding details</a>
                 </div>
+                <div class="hero-scroll">
+                    <span>Scroll</span>
+                    <span class="hero-scroll-line"></span>
+                </div>
+            </div>
+        </section>
+
+        <section id="highlights" class="scroll-panel" data-scroll-section>
+            <div class="scroll-panel-media" data-scroll-media>
+                <img src="assets/images/wedding_highlight_bride_vineyard.jpg" alt="Frances in the vineyard with bouquet"/>
+            </div>
+            <div class="scroll-panel-content">
+                <div class="scroll-panel-foreground" data-scroll-foreground data-reveal>
+                    <div class="panel-card">
+                        <p class="eyebrow">Wedding Highlights</p>
+                        <h2 class="section-title">A decade later, the day still glows</h2>
+                        <p class="section-lede">Ten years on, these snapshots still feel like the opening chapter of everything that followed.</p>
+                        <div class="panel-gallery">
+                            <img src="assets/images/wedding_highlight_sunset.jpg" alt="Silhouette kiss at sunset"/>
+                            <img src="assets/images/wedding_highlight_groom.jpg" alt="David getting ready with a red tie"/>
+                            <img src="assets/images/wedding_highlight_roses.jpg" alt="Close-up of the bouquet and smiles"/>
+                            <img src="assets/images/wedding_highlight_money.jpg" alt="Playful wedding portrait with money garlands"/>
+                            <img src="assets/images/wedding_highlight_palms.jpg" alt="Night dance under palm trees"/>
+                            <img src="assets/images/wedding_highlight_chandeliers.jpg" alt="Couple dancing under chandeliers"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="engagement" class="scroll-panel" data-scroll-section>
+            <div class="scroll-panel-media" data-scroll-media>
+                <img src="assets/images/engagement.jpg" alt="Frances and David engagement portrait"/>
+            </div>
+            <div class="scroll-panel-content">
+                <div class="scroll-panel-foreground" data-scroll-foreground data-reveal>
+                    <div class="panel-card">
+                        <p class="eyebrow">The Engagement</p>
+                        <h2 class="section-title">A promise kept close</h2>
+                        <p class="section-lede">When Frances moved back home from Massachusetts, David promised to keep her close—and he proposed. That quiet promise turned into a celebration, the start of a timeline the two of them keep adding to every year.</p>
+                        <div class="panel-icon-row">
+                            <div class="icon-chip">
+                                <span class="icon-chip-symbol">❤</span>
+                                <span>2015 proposal film</span>
+                            </div>
+                            <div class="icon-chip">
+                                <span class="icon-chip-symbol">✧</span>
+                                <span>Vows to grow together</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section section-immersive" id="proposal-film">
+            <div class="section-heading container" data-reveal>
+                <p class="eyebrow">Proposal Film</p>
+                <h2 class="section-title">The moment that started it all</h2>
+                <p class="section-lede">A cinematic keepsake to revisit every anniversary.</p>
             </div>
             <div class="container media-frame">
                 <iframe src="https://www.youtube.com/embed/FPimCVb5IhA" title="Proposal film" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
         </section>
 
-        <section id="story" class="section section-alt">
-            <div class="section-heading container">
-                <p class="eyebrow">College Beginnings</p>
-                <h2 class="section-title">How they met at UCSD</h2>
-                <p class="section-lede">Study sessions, late-night meals, and spontaneous adventures laid the foundation for everything that followed.</p>
+        <section id="story" class="scroll-panel" data-scroll-section>
+            <div class="scroll-panel-media" data-scroll-media>
+                <img src="assets/images/lupe_fiasco_concert_edited.jpg" alt="Early days at a Lupe Fiasco concert"/>
             </div>
-            <div class="container split-feature">
-                <div class="split-card">
-                    <h3>Campus nights</h3>
-                    <p>They met in college, bonding over group projects and long talks that stretched into the early hours. The friendship felt effortless and steady from the start.</p>
-                </div>
-                <div class="split-media">
-                    <img src="assets/images/lupe_fiasco_concert_edited.jpg" alt="Early days at a Lupe Fiasco concert"/>
+            <div class="scroll-panel-content">
+                <div class="scroll-panel-foreground" data-scroll-foreground data-reveal>
+                    <div class="panel-card">
+                        <p class="eyebrow">College Beginnings</p>
+                        <h2 class="section-title">How they met at UCSD</h2>
+                        <p class="section-lede">Study sessions, late-night meals, and spontaneous adventures laid the foundation for everything that followed.</p>
+                        <div class="panel-story-grid">
+                            <div>
+                                <h3>Campus nights</h3>
+                                <p>They met in college, bonding over group projects and long talks that stretched into the early hours. The friendship felt effortless and steady from the start.</p>
+                            </div>
+                            <div>
+                                <h3>Favorite memories</h3>
+                                <p>Concert nights, beach sunsets, and every first apartment meal became the stories they still laugh about today.</p>
+                            </div>
+                        </div>
+                        <div class="panel-image-strip">
+                            <img src="assets/images/first_anniversary_edited.jpg" alt="First anniversary portrait"/>
+                        </div>
+                    </div>
                 </div>
             </div>
-            <div class="container split-feature reverse">
-                <div class="split-media">
-                    <img src="assets/images/first_anniversary_edited.jpg" alt="First anniversary portrait"/>
-                </div>
-                <div class="split-card">
-                    <h3>Favorite memories</h3>
-                    <p>Concert nights, beach sunsets, and every first apartment meal became the stories they still laugh about today.</p>
-                </div>
-            </div>
-            <div class="section-heading container">
+        </section>
+
+        <section id="journal" class="section section-alt">
+            <div class="section-heading container" data-reveal>
                 <p class="eyebrow">Photo Journal</p>
                 <h2 class="section-title">Snapshots they keep adding to</h2>
             </div>
@@ -134,7 +160,7 @@
         </section>
 
         <section id="references" class="section">
-            <div class="container reference-links">
+            <div class="container reference-links" data-reveal>
                 <p class="eyebrow">Reference Links</p>
                 <p>Wedding details are here for quick reference: <a href="/wedding.html">Wedding details</a> · <a href="/program">Wedding program</a></p>
             </div>

--- a/views/index.html
+++ b/views/index.html
@@ -42,24 +42,11 @@
         </nav>
     </header>
     <main id="top">
-        <section id="film" class="hero-video">
+        <section id="film" class="hero-video hero-video--clear">
             <div class="hero-video-media">
                 <iframe id="vimeo-hero" src="https://player.vimeo.com/video/171783323?autoplay=1&muted=1&autopause=0&title=0&byline=0&portrait=0" title="Wedding film" frameborder="0" allow="autoplay; fullscreen"></iframe>
             </div>
             <div class="hero-video-overlay"></div>
-            <div class="hero-video-content" data-reveal>
-                <p class="eyebrow">Wedding Film</p>
-                <h1>The vows, the cheers, the first dance</h1>
-                <p class="hero-subtitle">The wedding day memories locked in a time capsule.</p>
-                <div class="hero-actions">
-                    <a class="button-primary" href="#highlights">Begin the story</a>
-                    <a class="button-secondary" href="#references">Wedding details</a>
-                </div>
-                <div class="hero-scroll">
-                    <span>Scroll</span>
-                    <span class="hero-scroll-line"></span>
-                </div>
-            </div>
         </section>
 
         <section id="highlights" class="scroll-panel" data-scroll-section>

--- a/views/index.html
+++ b/views/index.html
@@ -44,7 +44,7 @@
     <main id="top">
         <section id="film" class="hero-video">
             <div class="hero-video-media">
-                <iframe src="https://player.vimeo.com/video/171783323?autoplay=1&muted=1&autopause=0&title=0&byline=0&portrait=0" title="Wedding film" frameborder="0" allow="autoplay; fullscreen"></iframe>
+                <iframe id="vimeo-hero" src="https://player.vimeo.com/video/171783323?autoplay=1&muted=1&autopause=0&title=0&byline=0&portrait=0" title="Wedding film" frameborder="0" allow="autoplay; fullscreen"></iframe>
             </div>
             <div class="hero-video-overlay"></div>
             <div class="hero-video-content" data-reveal>
@@ -87,7 +87,7 @@
 
         <section id="engagement" class="scroll-panel" data-scroll-section>
             <div class="scroll-panel-media" data-scroll-media>
-                <img src="assets/images/engagement.jpg" alt="Frances and David engagement portrait"/>
+                <img src="assets/images/wedding_highlight_palms.jpg" alt="Night dance under palm trees"/>
             </div>
             <div class="scroll-panel-content">
                 <div class="scroll-panel-foreground" data-scroll-foreground data-reveal>
@@ -96,10 +96,7 @@
                         <h2 class="section-title">A promise kept close</h2>
                         <p class="section-lede">When Frances moved back home from Massachusetts, David promised to keep her close—and he proposed. That quiet promise turned into a celebration, the start of a timeline the two of them keep adding to every year.</p>
                         <div class="panel-icon-row">
-                            <div class="icon-chip">
-                                <span class="icon-chip-symbol">❤</span>
-                                <span>2015 proposal film</span>
-                            </div>
+                            <a class="button-primary proposal-button" href="#proposal-film" data-proposal-trigger>2014 proposal film</a>
                             <div class="icon-chip">
                                 <span class="icon-chip-symbol">✧</span>
                                 <span>Vows to grow together</span>
@@ -117,13 +114,13 @@
                 <p class="section-lede">A cinematic keepsake to revisit every anniversary.</p>
             </div>
             <div class="container media-frame">
-                <iframe src="https://www.youtube.com/embed/FPimCVb5IhA" title="Proposal film" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                <iframe data-proposal-video data-autoplay-src="https://www.youtube.com/embed/FPimCVb5IhA?autoplay=1&rel=0" src="https://www.youtube.com/embed/FPimCVb5IhA?rel=0" title="Proposal film" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </div>
         </section>
 
         <section id="story" class="scroll-panel" data-scroll-section>
             <div class="scroll-panel-media" data-scroll-media>
-                <img src="assets/images/lupe_fiasco_concert_edited.jpg" alt="Early days at a Lupe Fiasco concert"/>
+                <img src="assets/images/geisel_library_ucsd.svg" alt="Geisel Library at UC San Diego"/>
             </div>
             <div class="scroll-panel-content">
                 <div class="scroll-panel-foreground" data-scroll-foreground data-reveal>

--- a/views/program.html
+++ b/views/program.html
@@ -38,6 +38,17 @@
             </div>
         </nav>
     </header>
+    <section class="page-hero">
+        <div class="page-hero-media">
+            <img src="assets/images/wedding_highlight_palms.jpg" alt="Night dance under palm trees"/>
+        </div>
+        <div class="page-hero-overlay"></div>
+        <div class="page-hero-content" data-reveal>
+            <p class="eyebrow">Wedding Program</p>
+            <h1>Celebrating the ceremony</h1>
+            <p class="hero-subtitle">A ceremony outline and wedding party list for the day of the celebration.</p>
+        </div>
+    </section>
     <section>
         <div class="content">
             <a name="ceremony"></a>


### PR DESCRIPTION
### Motivation
- Preserve the existing wedding content as a single canonical reference to inform a redesign. 
- Reimagine the homepage as a timeline-style, immersive storytelling experience that foregrounds the wedding film and highlights while keeping details accessible.
- Provide a themed visual system (dark/immersive) and reusable reveal/scroll behavior to support parallax-style panels and consistent program/section presentation.

### Description
- Added `docs/Story.MD` to capture and centralize the existing home, wedding details, and program content for reference. 
- Rebuilt the homepage `views/index.html` into an immersive layout with a full-screen video hero, scroll-driven panels (`data-scroll-section`, `data-scroll-foreground`) and in-panel cards; added the proposal film and rearranged highlights, engagement, story, and journal sections. 
- Introduced theme tokens and dark/immersive styles in `assets/css/main.css`, `assets/css/nav.css`, and `assets/css/content.css`, and added new component styles for `hero-video`, `scroll-panel`, `panel-card`, `page-hero`, and reveal animations. 
- Replaced the previous highlight animation with a generic scroll-panel system and an IntersectionObserver-based reveal flow in `assets/js/index.js`, and wired reveal handling into `assets/js/program.js`; added a program page hero in `views/program.html`.

### Testing
- Started the local server with `npm run local`, which started successfully at `http://127.0.0.1:8000`. 
- Ran a Playwright script to load the homepage and capture a full-page screenshot (`artifacts/home-redesign.png`), which completed and produced the artifact. 
- No unit or CI test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bcf77a548832e9e6c4c2a98299223)