### PR TITLE
Use default port 3000 for local dev so Codex preview screenshots resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ npm run local
 ```
 
 `npm run local` binds to `0.0.0.0` so browser automation and screenshot tools can reach the server through forwarded ports.
+It keeps the default `3000` port so Codex preview screenshots reach the correct service (port `8000` is reserved by the preview proxy).
 If you only bind to `127.0.0.1`, external browser containers will return a Not Found page.
 
 ## Running on Windows
@@ -31,14 +32,14 @@ by setting `HOST` and `PORT` in your shell first.
 **PowerShell**
 ```powershell
 $env:HOST="0.0.0.0"
-$env:PORT="8000"
+$env:PORT="3000"
 node index.js
 ```
 
 **Command Prompt (cmd.exe)**
 ```cmd
 set HOST=0.0.0.0
-set PORT=8000
+set PORT=3000
 node index.js
 ```
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "node tests/smoke-test.js",
     "start": "node index.js",
-    "local": "HOST=0.0.0.0 PORT=8000 node index.js"
+    "local": "HOST=0.0.0.0 node index.js"
   },
   "author": "David Dizon",
   "license": "MIT",


### PR DESCRIPTION
### Motivation
- Avoid Codex preview proxy collisions that caused a "Not Found" page by binding the server to `0.0.0.0` while keeping the default port `3000` instead of forcing `8000`.

### Description
- Change the `local` npm script in `package.json` to `HOST=0.0.0.0 node index.js` and update `README.md` to document that `npm run local` uses port `3000` and to align Windows examples to `3000`.

### Testing
- Verified with an automated Playwright run that `http://127.0.0.1:3000/` returns `200` and produced screenshots (`artifacts/home.png`, `artifacts/program.png`, `artifacts/wedding.png`), while the same flow to port `8000` previously returned `404`, confirming the Not Found screenshot issue is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c27e3bde8832eb49764ee20068ada)