### PR TITLE
Simplify homepage hero: remove foreground card and surface video

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -181,6 +181,7 @@ var scrollSections = Array.prototype.slice.call(document.querySelectorAll('[data
 var revealTargets = Array.prototype.slice.call(document.querySelectorAll('[data-reveal]'));
 var scrollTicking = false;
 var heroSection = document.querySelector('.hero-video');
+var heroContent = heroSection ? heroSection.querySelector('.hero-video-content') : null;
 
 var clamp = function(value, min, max) {
     return Math.min(Math.max(value, min), max);
@@ -219,13 +220,15 @@ if (scrollSections.length) {
     requestScrollUpdate();
 }
 
-if (heroSection) {
+if (heroSection && heroContent) {
     var updateHeroVisibility = function() {
         heroSection.classList.toggle('hero-video--clear', window.scrollY > 40);
     };
 
     window.addEventListener('scroll', updateHeroVisibility, { passive: true });
     updateHeroVisibility();
+} else if (heroSection) {
+    heroSection.classList.add('hero-video--clear');
 }
 
 if (revealTargets.length) {

--- a/docs/tasks/003-timeline-experience-refresh.md
+++ b/docs/tasks/003-timeline-experience-refresh.md
@@ -25,6 +25,7 @@ Cite this prompt in the task file that you're creating."
 - [ ] Reorder the homepage sections to match the requested timeline flow.
 - [ ] Use existing wedding highlight photos in a full-width layout.
 - [ ] Autoplay the Vimeo wedding film on load (muted).
+- [ ] Present the wedding film as a full-bleed hero without the foreground text panel.
 - [ ] Move the engagement hero image into the timeline with the requested narrative.
 - [ ] Add a story segment for college memories and favorites.
 - [ ] Add subtle wedding details + program links at the bottom.

--- a/views/index.html
+++ b/views/index.html
@@ -42,24 +42,11 @@
         </nav>
     </header>
     <main id="top">
-        <section id="film" class="hero-video">
+        <section id="film" class="hero-video hero-video--clear">
             <div class="hero-video-media">
                 <iframe id="vimeo-hero" src="https://player.vimeo.com/video/171783323?autoplay=1&muted=1&autopause=0&title=0&byline=0&portrait=0" title="Wedding film" frameborder="0" allow="autoplay; fullscreen"></iframe>
             </div>
             <div class="hero-video-overlay"></div>
-            <div class="hero-video-content" data-reveal>
-                <p class="eyebrow">Wedding Film</p>
-                <h1>The vows, the cheers, the first dance</h1>
-                <p class="hero-subtitle">The wedding day memories locked in a time capsule.</p>
-                <div class="hero-actions">
-                    <a class="button-primary" href="#highlights">Begin the story</a>
-                    <a class="button-secondary" href="#references">Wedding details</a>
-                </div>
-                <div class="hero-scroll">
-                    <span>Scroll</span>
-                    <span class="hero-scroll-line"></span>
-                </div>
-            </div>
         </section>
 
         <section id="highlights" class="scroll-panel" data-scroll-section>


### PR DESCRIPTION
### Motivation
- Make the wedding film the primary visual at the top of the homepage by removing the foreground text panel, CTAs, and other overlay content so the video reads as a full-bleed hero and aligns with the timeline redesign.

### Description
- Removed the `.hero-video-content` markup from `views/index.html`, added the `hero-video--clear` class to the hero section, updated `assets/js/index.js` to keep the hero in clear mode when the content panel is absent, and noted the change in `docs/tasks/003-timeline-experience-refresh.md`.

### Testing
- Started a local HTTP server and captured a visual verification screenshot with Playwright at `artifacts/hero-video-full.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c2aa7fb08832eb7a098cb976947cc)