### PR TITLE
Document Codex preview port guidance

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -4,6 +4,10 @@
 - Track modernization tasks in `docs/tasks/` using numeric prefixes (e.g., `001-modernizing-droplet.md`).
 - Keep README updates aligned with the tasks so operators can follow a consistent checklist.
 
+## Preview screenshots (Codex)
+- When running the app for previews/screenshots, bind to 0.0.0.0 and keep the default port 3000.
+- Avoid port 8000, which is reserved by the Codex preview proxy and will show a “Not Found” page.
+
 ## Documentation workflow
 - If deployment instructions change, update both the README and the relevant task file.
 - Prefer concrete, step-by-step deployment guidance over high-level descriptions.

--- a/docs/tasks/004-codex-preview-guidance.md
+++ b/docs/tasks/004-codex-preview-guidance.md
@@ -1,0 +1,12 @@
+# 004 - Codex Preview Port Guidance
+
+## Goal
+Mention that automated previews/screenshots should use the correct host/port to avoid “Not Found”.
+
+## Tasks
+- [ ] Update local dev guidance to keep port 3000 while binding 0.0.0.0.
+- [ ] Align Windows examples with port 3000.
+- [ ] Document preview instructions for agents to avoid port 8000.
+
+## Notes
+Codex preview proxies reserve port 8000; use 3000 for this project when running previews.


### PR DESCRIPTION
### Motivation
- Ensure automated Codex preview screenshots bind to `0.0.0.0` and use the project's default port `3000` to prevent a reserved-proxy "Not Found" response.
- Record and surface port guidance for contributors and preview agents to avoid accidental usage of the reserved port `8000`.

### Description
- Add a `Preview screenshots (Codex)` section to `.codex/AGENTS.md` instructing to bind to `0.0.0.0`, keep port `3000`, and avoid port `8000`.
- Create `docs/tasks/004-codex-preview-guidance.md` titled `# 004 - Codex Preview Port Guidance` with a goal, a checklist (including Windows examples and binding/port guidance), and a note that Codex preview proxies reserve port `8000`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c3125ae6c832eae929cf9e8341dba)