### PR TITLE
Refine task tracking guidance and add task 005 for saving wedding details

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,7 +1,7 @@
 # Codex Working Agreements
 
 ## Task tracking
-- Track modernization tasks in `docs/tasks/` using numeric prefixes (e.g., `001-modernizing-droplet.md`).
+- Track all tasks in `docs/tasks/` using numeric prefixes (e.g., `001-modernizing-droplet.md`). Before starting work, check whether the task already exists; if it does, update that task, and if it does not, create a new task file.
 - Keep README updates aligned with the tasks so operators can follow a consistent checklist.
 
 ## Preview screenshots (Codex)

--- a/docs/tasks/005-save-wedding-details-to-story-redesign.md
+++ b/docs/tasks/005-save-wedding-details-to-story-redesign.md
@@ -1,0 +1,12 @@
+# 005 - Save Wedding Details to Story + Redesign Website
+
+## Summary
+Capture wedding details in the story documentation while redesigning the website experience to align with the updated narrative.
+
+## Source prompt
+"codex/save-wedding-details-to-story.md-and-redesign-website"
+
+## Checklist
+- [ ] Confirm the wedding details live in `docs/Story.MD` with clear references to the wedding and program pages.
+- [ ] Align the homepage redesign with the updated story details.
+- [ ] Validate that the storytelling flow matches the saved wedding details.


### PR DESCRIPTION
### Motivation
- Make task-tracking guidance apply to all tasks (not just modernization) so agents consistently check `docs/tasks/` before starting work.
- Record the work to capture “save wedding details” plus a website redesign as a tracked task.

### Description
- Updated `.codex/AGENTS.md` to consolidate the modernization-specific note into a single workflow bullet that requires tracking all tasks in `docs/tasks/` with numeric prefixes and checking/creating the task before starting.
- Preserved the README-alignment guidance in ` .codex/AGENTS.md` to keep operator checklists consistent.
- Added `docs/tasks/005-save-wedding-details-to-story-redesign.md` containing a summary, `Source prompt`, and a checklist for saving wedding details and aligning the homepage redesign.

### Testing
- These are documentation-only changes so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c32889d28832e94acbe14d73d8319)