### PR TITLE
Chore/update agents workflow

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -9,8 +9,14 @@
 - Avoid port 8000, which is reserved by the Codex preview proxy and will show a “Not Found” page.
 
 ## Documentation workflow
-- If deployment instructions change, update both the README and the relevant task file.
+- If deployment instructions change, update both the README and the `docs/tasks` file.
 - Prefer concrete, step-by-step deployment guidance over high-level descriptions.
+
+## Development Workflow
+- When working on a new task/chat session, make changes in a new git worktree (e.g, `.worktrees/YYYY-MM-DD-task-name`) using the `git worktree` commands (use `git worktree --help` to figure it out)
+- Once done with an implementation, run all relevant build, test, lint, etc. steps.
+- Use Conventional Commits for commit messages
+- When asking to push changes to a new pull-request, make sure the source branch is based off the latest origin/main.
 
 ## Creative direction (persistent prompt)
 You're world class web designer and expert front-end engineer, take my requests and treat it like you've been hired to work on this project.

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -8,13 +8,14 @@
 - When running the app for previews/screenshots, bind to 0.0.0.0 and keep the default port 3000.
 - Avoid port 8000, which is reserved by the Codex preview proxy and will show a “Not Found” page.
 
-## Documentation workflow
+## Documentation
 - If deployment instructions change, update both the README and the `docs/tasks` file.
 - Prefer concrete, step-by-step deployment guidance over high-level descriptions.
 
 ## Development Workflow
 - When working on a new task/chat session, make changes in a new git worktree (e.g, `.worktrees/YYYY-MM-DD-task-name`) using the `git worktree` commands (use `git worktree --help` to figure it out)
 - Once done with an implementation, run all relevant build, test, lint, etc. steps.
+- Before commit, check the `Task tracking` and `Documentation` workflows, try to include these into the same commit as the changes.
 - Use Conventional Commits for commit messages
 - When asking to push changes to a new pull-request, make sure the source branch is based off the latest origin/main.
 

--- a/docs/tasks/006-agents-workflow-guidance.md
+++ b/docs/tasks/006-agents-workflow-guidance.md
@@ -1,0 +1,8 @@
+# Task 006: AGENTS workflow guidance update
+
+## Summary
+- Capture new workflow guidance for worktrees, conventional commits, and PR base requirements.
+
+## Checklist
+- [x] Update `.codex/AGENTS.md` with the new workflow guidance.
+- [ ] Confirm the team has reviewed the updated guidance.


### PR DESCRIPTION
## Summary
- document new workflow guidance for worktrees, conventional commits, and PR base
- add a task entry for this guidance update

## Testing
- Not run (docs changes)
