### PR TITLE
fix: restore photo journal grid sizing

### DIFF
--- a/assets/css/photos.css
+++ b/assets/css/photos.css
@@ -1,20 +1,26 @@
 /* Flickr Photos styles*/
 .photos .flickr-container {
     list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
 .photos .flickr-container li {
-    display: inline;
+    display: block;
+}
+
+.photos .flickr-container a {
+    display: block;
 }
 
 .photos .flickr-container .item {
     margin-bottom: 5px;
-    width: 220px;
+    width: clamp(140px, 18vw, 220px);
     border-radius: 16px;
     box-shadow: 0 12px 20px rgba(16, 19, 26, 0.12);
     overflow: hidden;
-    width: 100%;
     display: block;
+    height: auto;
 }
 
 /* source from http://osvaldas.info/image-lightbox-responsive-touch-friendly */

--- a/docs/tasks/010-photo-journal-grid-sizing.md
+++ b/docs/tasks/010-photo-journal-grid-sizing.md
@@ -1,0 +1,8 @@
+# Task 010: Restore photo journal grid sizing
+
+## Summary
+Restore the responsive, multi-column thumbnail grid for the local Flickr photo journal so the tiles match the intended scale.
+
+## Checklist
+- [x] Adjust photo journal styles to bring back the responsive grid.
+- [x] Confirm the thumbnails render at the intended size on desktop and mobile.


### PR DESCRIPTION
## Summary
- Restore the photo journal thumbnails to a responsive masonry grid size.
- Reset gallery list/anchor display styles to prevent full-width tiles.
- Track the work in a new task checklist.

## Testing
- Not run (visual change only; user verified in browser).