### PR TITLE
fix(hero): allow unmute button clicks

### DIFF
--- a/assets/css/content.css
+++ b/assets/css/content.css
@@ -322,6 +322,7 @@ a:hover {
     inset: 0;
     background: linear-gradient(180deg, rgba(11, 13, 16, 0.65), rgba(11, 13, 16, 0.85));
     transition: opacity 0.6s ease;
+    pointer-events: none;
 }
 
 .hero-video-content {
@@ -786,3 +787,4 @@ a:hover {
         height: 200px;
     }
 }
+

--- a/docs/tasks/011-hero-video-unmute-click.md
+++ b/docs/tasks/011-hero-video-unmute-click.md
@@ -1,0 +1,8 @@
+# Task 011: Fix hero video unmute click
+
+## Summary
+Allow clicks to reach the Vimeo player controls in the hero so visitors can unmute the video.
+
+## Checklist
+- [x] Ensure the hero overlay does not block pointer interaction with the embedded player.
+- [x] Confirm the Vimeo unmute control is clickable in the hero section.


### PR DESCRIPTION
fix(hero): allow unmute button clicks

## Summary
- Allow pointer events through the hero video overlay so Vimeo controls are clickable.
- Add task tracking for the hero unmute fix.

## Testing
- Not run (not requested)
