### PR TITLE
ci: install Playwright browsers before tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
           cache: "npm"
       - name: Install dependencies
         run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
       - name: Run tests
         run: npm test
 

--- a/docs/tasks/014-deploy-install-tests.md
+++ b/docs/tasks/014-deploy-install-tests.md
@@ -8,12 +8,13 @@ Keep production installs dev-free while ensuring the lock file stays in sync and
 - [x] Add a production install script for deployment usage.
 - [x] Update the deploy workflow to use the production install script.
 - [x] Add a GitHub Action job that runs `npm test`.
+- [x] Install Playwright browsers in CI before running tests.
 - [x] Remove `package-lock.json` from `.gitignore`.
 - [x] Loosen Node engine range to allow v24.
 - [ ] Smoke test (or document if skipped).
 
 ## Decisions
-- None yet.
+- Use `npx playwright install --with-deps` in CI so browser binaries and OS deps are available.
 
 ## Notes
 - Smoke tests not run in this environment.


### PR DESCRIPTION
## Motivation
The CI test job fails because Playwright browsers aren’t installed on the GitHub runner.

## Changes
- Install Playwright browsers and OS deps in the test job before `npm test`.
- Record the CI decision in the task log.

## Testing
- `npm test`
