### PR TITLE
test: add CTA button browser coverage

### DIFF
--- a/docs/tasks/013-cta-button-tests.md
+++ b/docs/tasks/013-cta-button-tests.md
@@ -1,0 +1,13 @@
+# 013 - CTA button click tests
+
+## Goal
+Add browser coverage that confirms primary call-to-action buttons remain clickable.
+
+## Checklist
+- [x] Add a Playwright test that clicks the proposal CTA on the homepage.
+- [x] Add a Playwright test that clicks the wedding schedule CTA.
+- [x] Add a Playwright test that dismisses the program modal CTA.
+- [x] Update the npm test script to include the new CTA test.
+
+## Decisions
+- None.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "install:prod": "npm ci --omit=dev",
-    "test": "node tests/smoke-test.js && node tests/browser-modal-test.js && node tests/browser-scroll-panel-test.js",
+    "test": "node tests/smoke-test.js && node tests/browser-modal-test.js && node tests/browser-scroll-panel-test.js && node tests/browser-cta-test.js",
     "start": "node index.js",
     "local": "HOST=0.0.0.0 node index.js"
   },

--- a/tests/browser-cta-test.js
+++ b/tests/browser-cta-test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const assert = require('assert');
+const { chromium } = require('playwright');
+const { startServer } = require('../index');
+
+const run = async () => {
+    const server = await startServer({ host: '127.0.0.1', port: 0 });
+    let browser;
+    try {
+        browser = await chromium.launch({
+            headless: true,
+            args: ['--no-sandbox']
+        });
+        const page = await browser.newPage();
+
+        await page.goto(`http://127.0.0.1:${server.info.port}/`, { waitUntil: 'load' });
+        const proposalButton = await page.waitForSelector('[data-proposal-trigger]', { state: 'visible', timeout: 5000 });
+        const proposalVideo = await page.waitForSelector('[data-proposal-video]', { state: 'attached', timeout: 5000 });
+        const autoplaySrc = await proposalVideo.getAttribute('data-autoplay-src');
+        const initialSrc = await proposalVideo.getAttribute('src');
+        assert.ok(autoplaySrc, 'Expected proposal video autoplay src to be defined');
+        assert.ok(!initialSrc || !initialSrc.includes('autoplay=1'), 'Expected proposal video src to start without autoplay');
+
+        await proposalButton.click();
+        await page.waitForFunction((el) => {
+            const src = el.getAttribute('src') || '';
+            return src.includes('autoplay=1');
+        }, proposalVideo);
+
+        await page.goto(`http://127.0.0.1:${server.info.port}/wedding.html`, { waitUntil: 'load' });
+        const scheduleButton = await page.waitForSelector('a.button-primary[href="#details"]', { state: 'visible', timeout: 5000 });
+        await scheduleButton.click();
+        await page.waitForFunction(() => window.location.hash === '#details');
+
+        await page.goto(`http://127.0.0.1:${server.info.port}/program`, { waitUntil: 'load' });
+        await page.waitForSelector('#pleaseNoPhotos', { state: 'visible', timeout: 5000 });
+        const modalButton = await page.waitForSelector('#pleaseNoPhotos [data-dismiss="modal"]', { state: 'visible', timeout: 5000 });
+        await modalButton.click();
+        await page.waitForSelector('#pleaseNoPhotos', { state: 'hidden', timeout: 5000 });
+
+        console.log('Browser CTA test passed.');
+    } finally {
+        if (browser) {
+            await browser.close();
+        }
+        await server.stop();
+    }
+};
+
+run().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});


### PR DESCRIPTION
## What/Why
- Add browser coverage to ensure key call-to-action buttons stay clickable (proposal CTA, wedding schedule CTA, and program modal dismiss).
- Extend the test script so these CTA checks run with the existing Playwright suite.
- Track the task in a dedicated doc for future reference.

## Changes
- Add Playwright CTA test in `tests/browser-cta-test.js`.
- Update `npm test` to include the CTA test in `package.json`.
- Document the work in `docs/tasks/013-cta-button-tests.md`.

## Testing
- `npm test`" 2>&1