### PR TITLE
fix: guard maps init for CSP

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -54,8 +54,8 @@ $(function() {
 // Maps, Thanks St. John!
 // inspired by laurenandstjohn.com
 var maps = {
-    map: 0,
-    start: new google.maps.LatLng(37.5418658, -122.0403038),
+    map: null,
+    start: { lat: 37.5418658, lng: -122.0403038 },
     locs: {
         'winery': {
             title: 'Palm Event Center in the Vineyard',
@@ -64,7 +64,7 @@ var maps = {
             phone: '(925) 426-8666',
             logo: 'winery.jpg',
             icon: 'wedding.png',
-            loc: new google.maps.LatLng(37.6544662, -121.8227174)
+            loc: { lat: 37.6544662, lng: -121.8227174 }
         },
         'air-sfo': {
             title: 'San Francisco Airport (SFO)',
@@ -73,7 +73,7 @@ var maps = {
             phone: '(650) 821-8211',
             logo: 'air-sfo.gif',
             icon: 'airport.png',
-            loc: new google.maps.LatLng(37.6468459, -122.404285)
+            loc: { lat: 37.6468459, lng: -122.404285 }
         },
         'air-sjc': {
             title: 'San Jose International Airport (SJC)',
@@ -82,7 +82,7 @@ var maps = {
             phone: '(408) 501-0979',
             logo: 'air-sjc.gif',
             icon: 'airport.png',
-            loc: new google.maps.LatLng(37.357818, -121.917322)
+            loc: { lat: 37.357818, lng: -121.917322 }
         },
         'air-oak': {
             title: 'Oakland International Airport (OAK)',
@@ -91,7 +91,7 @@ var maps = {
             phone: '(510) 563-3300',
             logo: 'air-oak.jpg',
             icon: 'airport.png',
-            loc: new google.maps.LatLng(37.7125689, -122.2197428)
+            loc: { lat: 37.7125689, lng: -122.2197428 }
         },
         'hot-crt': {
             title: 'Courtyard Livermore',
@@ -100,7 +100,7 @@ var maps = {
             phone: '(925) 243-1000',
             logo: 'hot-crt.jpg',
             icon: 'villa-tourism.png',
-            loc: new google.maps.LatLng(37.7034248, -121.8171543)
+            loc: { lat: 37.7034248, lng: -121.8171543 }
         },
         'hot-hmp': {
             title: 'Hampton Inn Livermore',
@@ -109,33 +109,47 @@ var maps = {
             phone: '(925) 606-6400',
             logo: 'hot-hmp.jpg',
             icon: 'villa-tourism.png',
-            loc: new google.maps.LatLng(37.7028258, -121.8173644)
+            loc: { lat: 37.7028258, lng: -121.8173644 }
         }
     },
     markers: {},
     infos: {},
+    ready: function() {
+        return window.google && google.maps;
+    },
     open: function(index) {
-        if (this.locs[index]) {
-            $.each(this.infos, function(index, value) {
-                value.close();
-            })
-            this.map.panTo(this.locs[index].loc);
-            this.infos[index].open(this.map, this.markers[index]);
+        if (!this.map || !this.locs[index] || !this.locs[index].loc) {
+            return false;
         }
+
+        $.each(this.infos, function(index, value) {
+            value.close();
+        })
+        this.map.panTo(this.locs[index].loc);
+        this.infos[index].open(this.map, this.markers[index]);
 
         return false;
     },
     load: function() {
+        if (!this.ready()) {
+            return false;
+        }
+
+        var start = new google.maps.LatLng(this.start.lat, this.start.lng);
         this.map = new google.maps.Map(
             document.getElementById("wedding-map"), {
                 zoom: 9,
                 disableDefaultUI: true,
                 scrollwheel: false,
-                center: this.start,
+                center: start,
                 mapTypeId: google.maps.MapTypeId.ROADMAP
             });
 
         $.each(this.locs, function(index, value) {
+            if (value.loc && typeof value.loc.lat === 'number') {
+                value.loc = new google.maps.LatLng(value.loc.lat, value.loc.lng);
+            }
+
             maps.infos[index] = new google.maps.InfoWindow({
                 content: '<div id="mapcontent"><img src="assets/images/' + value.logo +
                     '" width="50" height="50" alt="' + value.title + '" />' +

--- a/docs/tasks/014-csp-maps-guard.md
+++ b/docs/tasks/014-csp-maps-guard.md
@@ -1,0 +1,11 @@
+# 014 - Guard scroll logic from CSP-blocked Maps
+
+## Goal
+Prevent Google Maps CSP failures from breaking other homepage interactions.
+
+## Checklist
+- [x] Lazy-initialize Google Maps so a blocked script does not throw during parsing.
+- [x] Keep map link clicks as safe no-ops when Maps is unavailable.
+
+## Decisions
+- Delay creation of `google.maps.LatLng` until map initialization to keep unrelated UI scripts running.

--- a/docs/tasks/015-csp-maps-guard.md
+++ b/docs/tasks/015-csp-maps-guard.md
@@ -1,4 +1,4 @@
-# 014 - Guard scroll logic from CSP-blocked Maps
+# 015 - Guard scroll logic from CSP-blocked Maps
 
 ## Goal
 Prevent Google Maps CSP failures from breaking other homepage interactions.


### PR DESCRIPTION
## What/Why
- Avoid Google Maps CSP failures from breaking scroll/reveal behavior when the Maps script is blocked.
- Keep map-link clicks safe if Maps is unavailable.

## Changes
- Lazily initialize Maps objects and only reference `google.maps` when it is available.
- Document the task in `docs/tasks/015-csp-maps-guard.md`.

## Testing
- Rebased on latest `origin/main` and ran `npm test`