### PR TITLE
fix(layout): center photo journal grid and engagement image

### DIFF
--- a/assets/css/content.css
+++ b/assets/css/content.css
@@ -426,6 +426,12 @@ a:hover {
     filter: saturate(0.95);
 }
 
+@media (max-width: 768px) {
+    #engagement .scroll-panel-media img {
+        object-position: 60% center;
+    }
+}
+
 .scroll-panel-content {
     position: relative;
     min-height: 110vh;
@@ -787,4 +793,3 @@ a:hover {
         height: 200px;
     }
 }
-

--- a/assets/css/photos.css
+++ b/assets/css/photos.css
@@ -1,7 +1,7 @@
 /* Flickr Photos styles*/
 .photos .flickr-container {
     list-style: none;
-    margin: 0;
+    margin: 0 auto;
     padding: 0;
 }
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -15,6 +15,7 @@ $(function() {
         // set layoutMode
         layoutMode: 'masonry',
         isInitLayout: false,
+        fitWidth: true,
         masonry: {
             gutter: 5
         }

--- a/docs/tasks/016-center-photo-journal-and-engagement.md
+++ b/docs/tasks/016-center-photo-journal-and-engagement.md
@@ -1,0 +1,16 @@
+# Task 016: Center photo journal grid and engagement photo
+
+## Summary
+- Center the photo journal masonry grid on the page.
+- Center the engagement photo on mobile.
+
+## Checklist
+- [x] Identify the photo journal grid layout styles.
+- [x] Identify the engagement photo layout on mobile.
+- [x] Update styles to center the grid and hero image.
+- [x] Capture a screenshot if the change affects the UI.
+- [ ] Run relevant tests or document why not.
+
+## Decisions
+- Center the masonry grid by enabling Isotope `fitWidth` with auto margins on the list.
+- Shift the engagement image focal point on mobile with `object-position`.


### PR DESCRIPTION
### Motivation
- Center the photo journal masonry grid so the gallery appears visually centered on the page.
- Keep the engagement hero image focal point better centered on small viewports to improve mobile composition.
- Record the layout change in project documentation for traceability.

### Description
- Enable Isotope `fitWidth` in `assets/js/index.js` so the masonry layout can be horizontally centered.
- Add `margin: 0 auto` to `.photos .flickr-container` in `assets/css/photos.css` to center the list container.
- Add a mobile rule in `assets/css/content.css` (`@media (max-width: 768px)`) setting `#engagement .scroll-panel-media img { object-position: 60% center; }` to adjust the engagement photo focal point.
- Add `docs/tasks/016-center-photo-journal-and-engagement.md` documenting the decision, checklist, and captured screenshot.

### Testing
- Launched the app locally with `npm run local` and the Hapi server started successfully.
- Executed a Playwright script against the running site in a mobile viewport which produced the screenshot `artifacts/engagement-and-journal-centered.png` successfully.
- No additional automated unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d0fa1ec30832eb526e8e64c60d6ef)