### PR TITLE
chore(codex): scope worktree guidance to CLI

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -15,7 +15,7 @@
 
 ## Development Workflow
 - Ask clarifying questions if you are unsure about specifics, give the option to defer decisions
-- Before implementing a new task, and make changes to the local git, create a new git worktree (e.g, `.worktrees/YYYY-MM-DD-task-name`) using the `git worktree` commands (use `git worktree --help` to figure it out)
+- Only when using the Codex CLI: before implementing a new task and making changes to the local git, create a new git worktree (e.g, `.worktrees/YYYY-MM-DD-task-name`) using the `git worktree` commands (use `git worktree --help` to figure it out). Skip this when using the Codex webapp / ChatGPT app.
 - Once done with an implementation, run all relevant build, test, lint, etc. steps.
 - Before commit, check the `Task tracking` and `Documentation` workflows, try to include these into the same commit as the changes.
 - Use Conventional Commits for commit messages (see https://www.conventionalcommits.org/en):

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -27,8 +27,8 @@
     [optional footer(s)]
     ```
 - When asking to push changes to a new pull-request, make sure the source branch is based off the latest origin/main.
-- Always provide a detailed pull request description. Use original requests as a seed for motivation for filling the description.
-- After a PR is merged, remove the corresponding worktree (git worktree remove .worktrees/<name>) and delete the local branch (git branch -d <name>). If the branch isn’t merged into main locally yet, delete with -D only if the PR is confirmed merged.
+- Always provide a detailed pull request description. Use original requests as a seed for motivation for filling the description. Use the `gh-pr-description-formatting` skill whenever writing or editing PR descriptions.
+- After a PR is merged, remove the corresponding worktree (git worktree remove .worktrees/<name>) and delete the local branch (git branch -d <name>). If the branch isn't merged into main locally yet, delete with -D only if the PR is confirmed merged.
 
 ## Creative direction (persistent prompt)
 You're world class web designer and expert front-end engineer, take my requests and treat it like you've been hired to work on this project.

--- a/.codex/skills/gh-pr-description-formatting/SKILL.md
+++ b/.codex/skills/gh-pr-description-formatting/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: gh-pr-description-formatting
+description: Ensure GitHub PR descriptions created or edited via `gh pr create`/`gh pr edit` use real newlines (no literal \\n) and render correctly. Use when composing or updating PR descriptions from the CLI.
+---
+
+# PR Description Formatting (GitHub CLI)
+
+## Write the PR body with real newlines
+
+- Use a literal multi-line string (PowerShell here-string or a file) and pass it to `--body` or `--body-file`.
+- Do not embed `\n` escape sequences inside a single-line string; they will render literally.
+
+### PowerShell patterns (Windows)
+
+Use a here-string:
+
+```powershell
+$body = @'
+## Summary
+- First point
+- Second point
+
+## Testing
+- Not run (docs-only change)
+'@
+gh pr create --title "..." --body $body
+```
+
+Or write a temp file and pass `--body-file`:
+
+```powershell
+$bodyPath = Join-Path $env:TEMP "pr-body.md"
+@'
+## Summary
+- First point
+- Second point
+'@ | Set-Content $bodyPath
+gh pr edit 123 --body-file $bodyPath
+```
+
+### Bash patterns (Linux/macOS)
+
+Use a here-doc and `--body-file`:
+
+```bash
+cat <<'EOF' > /tmp/pr-body.md
+## Summary
+- First point
+- Second point
+
+## Testing
+- Not run (docs-only change)
+EOF
+gh pr edit 123 --body-file /tmp/pr-body.md
+```
+
+Or use ANSI-C quoting with real newlines:
+
+```bash
+body=$'## Summary\n- First point\n- Second point\n\n## Testing\n- Not run (docs-only change)\n'
+gh pr create --title "..." --body "$body"
+```
+
+## Verify formatting when needed
+
+- If unsure, confirm with `gh pr view <number> --json body --jq .body`.

--- a/docs/tasks/006-agents-workflow-guidance.md
+++ b/docs/tasks/006-agents-workflow-guidance.md
@@ -2,6 +2,7 @@
 
 ## Summary
 - Capture new workflow guidance for worktrees, conventional commits, and PR base requirements.
+- Decision: require git worktrees only when using the Codex CLI; skip for Codex webapp / ChatGPT app.
 
 ## Checklist
 - [x] Update `.codex/AGENTS.md` with the new workflow guidance.

--- a/docs/tasks/017-gh-pr-description-formatting-skill.md
+++ b/docs/tasks/017-gh-pr-description-formatting-skill.md
@@ -1,0 +1,11 @@
+# Task 017: PR description formatting skill
+
+## Summary
+- Add a Codex skill that prevents mangled PR descriptions by using real newlines with `gh pr create`/`gh pr edit`.
+
+## Checklist
+- [x] Create the skill folder and SKILL.md in the repository.
+- [x] Confirm the skill matches the desired behavior for CLI PR descriptions.
+
+## Decisions
+- Store the skill under `.codex/skills/` to keep Codex-specific guidance with the repo.


### PR DESCRIPTION
## Summary
- Scope the git worktree requirement to Codex CLI usage only
- Document the decision in task 006
- Add a skill for correctly formatting PR descriptions in GitHub CLI (Windows + Linux/macOS) and require it in AGENTS

## Testing
- Not run (docs-only change)