### PR TITLE
Add repo memory system for agents (ADRs + logs + tasks + CI check)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+## Memory System Checklist
+- [ ] Updated logs/ADR/tasks if needed
+- [ ] Added/updated risks or surprises if applicable
+- [ ] (Optional) Added refactor opportunities for later

--- a/.github/workflows/memory-check.yml
+++ b/.github/workflows/memory-check.yml
@@ -1,0 +1,15 @@
+name: Memory Check
+
+on:
+  pull_request:
+
+jobs:
+  memory-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run memory check
+        run: bash scripts/memory_check.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,47 @@ This repository's Codex instructions live in `.codex/AGENTS.md`.
 
 - Primary instructions: `.codex/AGENTS.md`
 - Additional instructions: (add paths here)
+
+## Repo Memory System
+
+This repo keeps durable context inside the codebase so humans and agents can find intent,
+decisions, risks, and ongoing work without external tools.
+
+### Where context lives
+
+- Work tracking: `docs/tasks/` (plans, migrations, multi-step changes)
+- Decisions: `docs/adr/` (Architecture Decision Records)
+- Living logs (append-only): `docs/log/changes.md`, `docs/log/decisions.md`,
+  `docs/log/risks.md`, `docs/log/surprises.md`
+- Refactor opportunities: `docs/refactor-opportunities.md` (non-blocking ideas)
+
+### When to update which artifact
+
+- Small but notable change -> `docs/log/changes.md`
+- Major decision with tradeoffs -> new ADR in `docs/adr/`
+- New risk or mitigation -> `docs/log/risks.md`
+- "We learned this the hard way" -> `docs/log/surprises.md`
+- Ongoing work -> existing `docs/tasks/*`
+
+### Entry schema (agent-friendly)
+
+Log entries should answer: **what / why / impact / risks / links**.
+
+Suggested fields:
+- Date
+- Type (Change | Decision | Risk | Surprise)
+- Motivation (why)
+- What changed
+- Impact
+- Risks & mitigations
+- Links (PR / Issue / ADR / Runbook)
+
+### Repo structure policy
+
+Do not rename or move existing code paths in docs/process PRs. Record structural
+improvements in `docs/refactor-opportunities.md` for later follow-up.
+
+### Bypass marker
+
+If no memory update is needed, include this marker in the PR description:
+`no-memory-update-needed`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,13 @@
+# Docs Index
+
+- `AGENTS.md`
+- `docs/tasks/`
+- `docs/tasks/_task-template.md`
+- `docs/log/changes.md`
+- `docs/log/decisions.md`
+- `docs/log/risks.md`
+- `docs/log/surprises.md`
+- `docs/log/_entry-template.md`
+- `docs/adr/`
+- `docs/adr/0000-template.md`
+- `docs/refactor-opportunities.md`

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,21 @@
+# ADR 0000: Title
+
+## Context
+
+Describe the situation and forces that led to this decision.
+
+## Decision
+
+State the decision clearly and concisely.
+
+## Consequences
+
+Describe expected outcomes, tradeoffs, and impacts.
+
+## Alternatives
+
+List the options considered and why they were not chosen.
+
+## Links
+
+Reference PRs, issues, and related docs.

--- a/docs/log/_entry-template.md
+++ b/docs/log/_entry-template.md
@@ -1,0 +1,9 @@
+# Log Entry Template
+
+- Date:
+- Type: Change | Decision | Risk | Surprise
+- Motivation:
+- What changed:
+- Impact:
+- Risks & mitigations:
+- Links: PR / Issue / ADR / Runbook

--- a/docs/log/changes.md
+++ b/docs/log/changes.md
@@ -1,0 +1,3 @@
+# Changes Log
+
+Append-only log of notable changes (not every commit). Use `docs/log/_entry-template.md`.

--- a/docs/log/decisions.md
+++ b/docs/log/decisions.md
@@ -1,0 +1,3 @@
+# Decisions Log
+
+Append-only log of decisions and links to ADRs. Use `docs/log/_entry-template.md`.

--- a/docs/log/risks.md
+++ b/docs/log/risks.md
@@ -1,0 +1,3 @@
+# Risks Log
+
+Append-only log of known risks and mitigations. Use `docs/log/_entry-template.md`.

--- a/docs/log/surprises.md
+++ b/docs/log/surprises.md
@@ -1,0 +1,3 @@
+# Surprises Log
+
+Append-only log of incidents, gotchas, and hard-earned lessons. Use `docs/log/_entry-template.md`.

--- a/docs/refactor-opportunities.md
+++ b/docs/refactor-opportunities.md
@@ -1,0 +1,21 @@
+# Refactor Opportunities
+
+Non-blocking improvements discovered during work. Capture ideas here, then follow up
+with tasks or PRs later.
+
+## How to add
+
+Template:
+- What:
+  Why:
+  Impact:
+  Suggested next step:
+  Links:
+
+## Opportunities
+
+- What: Replace non-ASCII control characters in `.codex/AGENTS.md` rule-of-thumb bullets.
+  Why: The characters render as garbled symbols in some editors and can cause encoding noise.
+  Impact: Cleaner instructions and fewer encoding issues for collaborators and agents.
+  Suggested next step: Normalize the rule-of-thumb bullets to ASCII in `.codex/AGENTS.md`.
+  Links: `.codex/AGENTS.md`

--- a/docs/tasks/_task-template.md
+++ b/docs/tasks/_task-template.md
@@ -1,0 +1,19 @@
+# Task: Title
+
+## Goal
+
+## Context
+
+## Current State
+
+## Next Steps
+- [ ]
+
+## Acceptance Criteria
+- [ ]
+
+## Links
+- 
+
+## Risks
+- 

--- a/scripts/memory_check.sh
+++ b/scripts/memory_check.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+marker="no-memory-update-needed"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Memory check: not a git repository. Skipping."
+  exit 0
+fi
+
+base_ref=""
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+  if git rev-parse --verify -q "origin/${GITHUB_BASE_REF}" >/dev/null; then
+    base_ref="origin/${GITHUB_BASE_REF}"
+  elif git rev-parse --verify -q "${GITHUB_BASE_REF}" >/dev/null; then
+    base_ref="${GITHUB_BASE_REF}"
+  fi
+fi
+
+if [[ -z "$base_ref" ]]; then
+  for candidate in "origin/main" "main" "origin/master" "master"; do
+    if git rev-parse --verify -q "$candidate" >/dev/null; then
+      base_ref="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$base_ref" ]]; then
+  echo "Memory check: no base ref found. Skipping."
+  exit 0
+fi
+
+if ! git merge-base "$base_ref" HEAD >/dev/null 2>&1; then
+  echo "Memory check: no merge base with $base_ref. Skipping."
+  exit 0
+fi
+
+changed_files=$(git diff --name-only "$base_ref"...HEAD)
+if [[ -z "$changed_files" ]]; then
+  echo "Memory check: no changed files."
+  exit 0
+fi
+
+pr_body=""
+if [[ -n "${GITHUB_EVENT_PATH:-}" && -f "${GITHUB_EVENT_PATH:-}" ]]; then
+  pr_body=$(python - <<'PY' 2>/dev/null || true
+import json
+import os
+path = os.environ.get("GITHUB_EVENT_PATH")
+if not path or not os.path.exists(path):
+    raise SystemExit(1)
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+pr = data.get("pull_request") or {}
+body = pr.get("body") or ""
+print(body)
+PY
+  )
+fi
+
+if [[ -n "$pr_body" ]] && echo "$pr_body" | grep -qi "$marker"; then
+  echo "Memory check: bypass marker found in PR description."
+  exit 0
+fi
+
+has_memory_update=0
+if echo "$changed_files" | grep -E -q '^(docs/(log|adr|tasks)/)'; then
+  has_memory_update=1
+fi
+
+requires_memory=0
+code_paths=(
+  "src/"
+  "app/"
+  "server/"
+  "packages/"
+  "infra/"
+  "deploy/"
+  "migrations/"
+  "services/"
+  "lib/"
+  "api/"
+  "config/"
+  "views/"
+)
+
+while IFS= read -r file; do
+  for path in "${code_paths[@]}"; do
+    if [[ "$file" == "$path"* ]]; then
+      requires_memory=1
+      break
+    fi
+  done
+  if [[ "$requires_memory" -eq 1 ]]; then
+    break
+  fi
+done <<< "$changed_files"
+
+if [[ "$requires_memory" -eq 0 ]]; then
+  auto_dirs=$(printf '%s\n' "$changed_files" | awk -F/ 'NF>1 {count[$1]++} END {for (d in count) if (count[d]>=3) print d}')
+  while IFS= read -r dir; do
+    case "$dir" in
+      docs|.github|.codex|scripts|tests|assets|node_modules|.worktrees)
+        continue
+        ;;
+    esac
+    if echo "$changed_files" | grep -E -q "^${dir}/"; then
+      requires_memory=1
+      break
+    fi
+  done <<< "$auto_dirs"
+fi
+
+if [[ "$requires_memory" -eq 1 && "$has_memory_update" -eq 0 ]]; then
+  echo "Memory check: significant code changes detected without context updates."
+  echo "Please update docs/log/, docs/adr/, or docs/tasks/, or add '$marker' to the PR body."
+  exit 1
+fi
+
+echo "Memory check: passed."


### PR DESCRIPTION
## Summary
- Add repo memory system docs, templates, and index for durable context (ADRs, logs, tasks, refactor ideas).
- Add a lightweight memory check script + GitHub Actions workflow and PR template checklist.
- Document repo memory system guidance in `AGENTS.md`.

## How to use
- Track work in `docs/tasks/`, decisions in `docs/adr/`, and living context in `docs/log/*`.
- For significant code changes, update logs/ADR/tasks or add `no-memory-update-needed` to the PR description.

## Notes
- No code paths were renamed or moved.

## Follow-ups
- `docs/refactor-opportunities.md`