### PR TITLE
chore(deploy): use github host alias for deploy key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,7 @@ jobs:
             fi
             cd "$APP_DIR"
             echo "==> Updating code"
+            git remote set-url origin git@github.com-francesanddavid:dvdizon/francesanddavid.git
             git fetch --all
             git reset --hard origin/main
             echo "==> Installing dependencies"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,20 @@ Required GitHub Secrets:
 One-time droplet setup checklist (Ubuntu assumed):
 
 1. **Create a deploy user and grant SSH access.**
-2. **Update the OS:**
+2. **Create a GitHub deploy key + SSH host alias:**
+
+   - Add the deploy key's public key to the GitHub repo as a deploy key.
+   - Configure an SSH host alias on the droplet for the new key:
+
+   ```sshconfig
+   Host github.com-francesanddavid
+     HostName github.com
+     User git
+     IdentityFile ~/.ssh/<deploy-key>
+     IdentitiesOnly yes
+   ```
+
+3. **Update the OS:**
 
    ```bash
    sudo apt update
@@ -79,7 +92,7 @@ One-time droplet setup checklist (Ubuntu assumed):
    sudo apt update
    ```
 
-3. **Install Node.js 20 LTS (or 18 LTS) and npm:**
+4. **Install Node.js 20 LTS (or 18 LTS) and npm:**
 
    ```bash
    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
@@ -98,7 +111,7 @@ One-time droplet setup checklist (Ubuntu assumed):
    sudo apt install -y nodejs
    ```
 
-4. **Clone the repository into the deploy path and set permissions:**
+5. **Clone the repository into the deploy path and set permissions:**
 
    ```bash
    sudo mkdir -p /var/www/francesanddavid
@@ -106,7 +119,7 @@ One-time droplet setup checklist (Ubuntu assumed):
    git clone <your-repo-url> /var/www/francesanddavid
    ```
 
-5. **Install PM2 globally and configure startup:**
+6. **Install PM2 globally and configure startup:**
 
    ```bash
    sudo npm install -g pm2
@@ -114,12 +127,12 @@ One-time droplet setup checklist (Ubuntu assumed):
    pm2 save
    ```
 
-6. **Ensure server-side environment variables exist:**
+7. **Ensure server-side environment variables exist:**
 
    Populate `/var/www/francesanddavid/.env` as needed. The deploy workflow does not
    overwrite this file.
 
-7. **Confirm Nginx proxies to the Node upstream:**
+8. **Confirm Nginx proxies to the Node upstream:**
 
    Nginx should proxy `http://127.0.0.1:3000`, and `/health` should return `200`.
 

--- a/docs/tasks/018-github-host-alias.md
+++ b/docs/tasks/018-github-host-alias.md
@@ -1,0 +1,13 @@
+# Task: Update deploy workflow host alias for GitHub
+
+## Checklist
+- [x] Review current deploy workflow host/ssh config
+- [x] Update GitHub host alias to github.com-francesanddavid in deploy step
+- [x] Validate workflow still references correct host alias
+
+## Notes
+- Requested to use github.com-francesanddavid as the Host alias for GitHub deploy actions.
+- Documented the SSH host alias in the GitHub Actions deployment checklist.
+
+## Decisions
+- Use the git remote alias github.com-francesanddavid in the deploy script to select the correct deploy key.


### PR DESCRIPTION
## Summary
- force the deploy script to set the GitHub remote to `github.com-francesanddavid` so the correct deploy key is used
- document the SSH host alias setup in the GitHub Actions droplet checklist
- add a task record for the deploy key alias change

## Testing
- not run (docs/workflow changes only)

## Notes
- assumes the repo slug remains `dvdizon/francesanddavid`