### PR TITLE
Update GitHub Pages deployment and custom domain guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,225 +44,43 @@ node index.js
 ```
 
 
-## Deploying to a DigitalOcean Droplet
+## Deploying to GitHub Pages
 
-### GitHub Actions deployment (recommended)
+These steps assume the site is served from this repo’s default branch and the HTML entry points live in the repository root.
 
-Required GitHub Secrets:
+1. **Confirm the repository is ready for Pages.**
+   - `index.html`, `program.html`, and `wedding.html` must be in the repository root.
+   - Asset and navigation paths should remain relative (for example, `assets/...`, `program.html`).
 
-- `DO_HOST` (droplet IP or hostname)
-- `DO_USER` (SSH user, e.g. `deploy`)
-- `DO_SSH_KEY` (private key, PEM format)
-- `DO_PORT` (optional, defaults to `22`)
+2. **Enable GitHub Pages.**
+   - Open **Settings → Pages** in the GitHub repository.
+   - Under **Build and deployment**, choose **Deploy from a branch**.
+   - Select the default branch (usually `main`) and **/(root)** as the folder.
+   - Save. GitHub will publish to `https://<org-or-user>.github.io/<repo>/`.
 
-One-time droplet setup checklist (Ubuntu assumed):
+3. **Verify the deployment.**
+   - Visit the Pages URL and confirm the homepage loads.
+   - Click through `program.html` and `wedding.html` to ensure routes and assets resolve.
 
-1. **Create a deploy user and grant SSH access.**
-2. **Create a GitHub deploy key + SSH host alias:**
+### Configure a custom domain
 
-   - Add the deploy key's public key to the GitHub repo as a deploy key.
-   - Configure an SSH host alias on the droplet for the new key:
+1. **Add the domain in GitHub Pages settings.**
+   - In **Settings → Pages**, enter your custom domain (for example, `francesanddavid.com`) and save.
+   - This writes a `CNAME` file at the repository root. If it does not, create `CNAME` manually with just the domain.
 
-   ```sshconfig
-   Host github.com-francesanddavid
-     HostName github.com
-     User git
-     IdentityFile ~/.ssh/<deploy-key>
-     IdentitiesOnly yes
-   ```
+2. **Update DNS at your registrar.**
+   - **Apex/root domain (`francesanddavid.com`):** add four `A` records pointing to GitHub Pages:
+     - `185.199.108.153`
+     - `185.199.109.153`
+     - `185.199.110.153`
+     - `185.199.111.153`
+   - **IPv6 (optional):** add `AAAA` records:
+     - `2606:50c0:8000::153`
+     - `2606:50c0:8001::153`
+     - `2606:50c0:8002::153`
+     - `2606:50c0:8003::153`
+   - **`www` subdomain:** add a `CNAME` record pointing to `<org-or-user>.github.io`.
 
-3. **Update the OS:**
-
-   ```bash
-   sudo apt update
-   sudo apt upgrade -y
-   ```
-
-   **Troubleshooting (DigitalOcean droplet agent repo):** If `apt update` fails with a
-   `NO_PUBKEY 35696F43FC7DB4C2` error or a 404 for `droplet-agent`, refresh the repo
-   key or remove the legacy source before retrying:
-
-   ```bash
-   # Option A: refresh the droplet agent repo key
-   curl -fsSL https://repos-droplet.digitalocean.com/gpgkey | \
-     sudo gpg --dearmor -o /usr/share/keyrings/droplet-agent-archive.gpg
-
-   # Option B: remove the droplet agent source if you don't need it
-   sudo rm -f /etc/apt/sources.list.d/droplet-agent.list
-   sudo apt update
-   ```
-
-4. **Install Node.js 20 LTS (or 18 LTS) and npm:**
-
-   ```bash
-   curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
-   sudo apt install -y nodejs
-   ```
-
-   **Troubleshooting (NodeSource GPG key):** If `apt update` or `apt install` fails with
-   `NO_PUBKEY 2F59B5F99B1BE0B4`, refresh the NodeSource key and repo, then retry:
-
-   ```bash
-   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
-     sudo gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
-   echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | \
-     sudo tee /etc/apt/sources.list.d/nodesource.list
-   sudo apt update
-   sudo apt install -y nodejs
-   ```
-
-5. **Clone the repository into the deploy path and set permissions:**
-
-   ```bash
-   sudo mkdir -p /var/www/francesanddavid
-   sudo chown -R <your-deploy-user>:<your-deploy-user> /var/www/francesanddavid
-   git clone <your-repo-url> /var/www/francesanddavid
-   ```
-
-6. **Install PM2 globally and configure startup:**
-
-   ```bash
-   sudo npm install -g pm2
-   pm2 startup
-   pm2 save
-   ```
-
-7. **Ensure server-side environment variables exist:**
-
-   Populate `/var/www/francesanddavid/.env` as needed. The deploy workflow does not
-   overwrite this file.
-
-8. **Confirm Nginx proxies to the Node upstream:**
-
-   Nginx should proxy `http://127.0.0.1:3000`, and `/health` should return `200`.
-
-Verify a deploy:
-
-```bash
-pm2 status francesanddavid
-curl -fsS http://127.0.0.1:3000/health
-pm2 logs francesanddavid --lines 80
-```
-
-### Manual deployment (fallback)
-
-These steps assume Ubuntu on your Droplet and that you want to keep costs low by continuing to run a single VM.
-
-1. **SSH into the Droplet and update the OS:**
-
-   ```bash
-   sudo apt update
-   sudo apt upgrade -y
-   ```
-
-   **Troubleshooting (DigitalOcean droplet agent repo):** If `apt update` fails with a
-   `NO_PUBKEY 35696F43FC7DB4C2` error or a 404 for `droplet-agent`, refresh the repo
-   key or remove the legacy source before retrying:
-
-   ```bash
-   # Option A: refresh the droplet agent repo key
-   curl -fsSL https://repos-droplet.digitalocean.com/gpgkey | \
-     sudo gpg --dearmor -o /usr/share/keyrings/droplet-agent-archive.gpg
-
-   # Option B: remove the droplet agent source if you don't need it
-   sudo rm -f /etc/apt/sources.list.d/droplet-agent.list
-   sudo apt update
-   ```
-
-2. **Install Node.js 20 LTS (or 18 LTS) and npm:**
-
-   ```bash
-   curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
-   sudo apt install -y nodejs
-   ```
-
-   **Troubleshooting (NodeSource GPG key):** If `apt update` or `apt install` fails with
-   `NO_PUBKEY 2F59B5F99B1BE0B4`, refresh the NodeSource key and repo, then retry:
-
-   ```bash
-   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
-     sudo gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
-   echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | \
-     sudo tee /etc/apt/sources.list.d/nodesource.list
-   sudo apt update
-   sudo apt install -y nodejs
-   ```
-
-3. **Clone the repository and install production dependencies:**
-
-   ```bash
-   git clone <your-repo-url>
-   cd francesanddavid
-   npm install --omit=dev
-   ```
-
-4. **Set environment variables for the server:**
-
-   ```bash
-   export HOST=0.0.0.0
-   export PORT=3000
-   ```
-
-5. **Start the server (choose one):**
-
-   - **PM2 (recommended for simplicity):**
-
-     ```bash
-     npm install -g pm2
-     pm2 start index.js --name francesanddavid
-     pm2 save
-     pm2 startup
-     ```
-
-   - **Systemd (for native service management):**
-
-     Create `/etc/systemd/system/francesanddavid.service` with:
-
-     ```ini
-     [Unit]
-     Description=Frances and David website
-     After=network.target
-
-     [Service]
-     Type=simple
-     WorkingDirectory=/path/to/francesanddavid
-     ExecStart=/usr/bin/node /path/to/francesanddavid/index.js
-     Restart=on-failure
-     Environment=HOST=0.0.0.0
-     Environment=PORT=3000
-
-     [Install]
-     WantedBy=multi-user.target
-     ```
-
-     Then enable it:
-
-     ```bash
-     sudo systemctl daemon-reload
-     sudo systemctl enable --now francesanddavid
-     ```
-
-6. **(Optional) Add Nginx for TLS + port 80/443:**
-
-   Use Nginx to proxy `https://your-domain` to `http://127.0.0.1:3000` so the Node app can stay on a non-root port.
-
-7. **Verify the deployment:**
-
-   ```bash
-   pm2 status francesanddavid
-   curl -fsS http://127.0.0.1:3000/health
-   ```
-
-   If you see `npm warn Unknown env config "http-proxy"`, unset any `npm_config_http_proxy`
-   (or similar) environment variables before running npm again.
-### HTTPS (Certbot + Nginx)
-
-If HTTPS is not working after you set up Nginx, make sure an SSL (port 443) server block exists for your domain. The easiest fix is to let Certbot configure it for you:
-
-```bash
-sudo apt install -y certbot python3-certbot-nginx
-sudo certbot --nginx -d your-domain.com -d www.your-domain.com
-
-
-```
-
+3. **Wait for DNS propagation, then enforce HTTPS.**
+   - After the custom domain resolves, return to **Settings → Pages** and enable **Enforce HTTPS**.
+   - If HTTPS is not available yet, give it a few minutes and retry once DNS settles.

--- a/docs/tasks/019-github-pages-migration-guidance.md
+++ b/docs/tasks/019-github-pages-migration-guidance.md
@@ -5,11 +5,13 @@
 - [x] Move HTML entry points to the repository root for GitHub Pages hosting
 - [x] Update links/asset paths to work without a server or custom domain
 - [x] Document GitHub Pages configuration steps and required repository settings
+- [x] Document custom domain + DNS configuration steps for GitHub Pages
 
 ## Notes
 - The site is static HTML with JS/CSS assets, now hosted from the repository root (`index.html`, `program.html`, `wedding.html`) so GitHub Pages can serve it directly.
 - Navigation and asset paths were updated to be relative (`assets/...`, `program.html`, `wedding.html`) so the site works whether hosted at a repo subpath or a custom domain.
 - Recommended deployment flow: enable Pages from the default branch and `/root`, then verify the published URL loads the homepage and subpages.
+- Custom domains require adding the domain in GitHub Pages settings, adding DNS `A` records for the apex, and a `CNAME` for `www`, then enabling HTTPS once DNS resolves.
 
 ## Decisions
 - Prefer a GitHub Pages "project site" deployment from the default branch, using root-level HTML files and relative paths to avoid custom-domain requirements.


### PR DESCRIPTION
### Motivation
- The site was migrated to a static layout intended to be served from the repository root using GitHub Pages, so the previous DigitalOcean/Droplet deployment instructions in the documentation are obsolete.
- Provide clear, step-by-step instructions for enabling GitHub Pages and configuring a custom domain so maintainers can publish the site without a server.

### Description
- Replaced the DigitalOcean/Droplet deployment section in `README.md` with GitHub Pages deployment steps and verification guidance, including requirements that `index.html`, `program.html`, and `wedding.html` live at the repo root.
- Added explicit custom domain guidance to `README.md`, including adding a `CNAME`, the required `A` and optional `AAAA` records, and the instruction to enable `Enforce HTTPS` in `Settings → Pages`.
- Updated `docs/tasks/019-github-pages-migration-guidance.md` to include custom domain and DNS configuration in the checklist and notes.
- Changes are documentation-only and were committed to the working branch (files modified: `README.md`, `docs/tasks/019-github-pages-migration-guidance.md`).

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d620a368832e8a8e7fa4e6c10182)